### PR TITLE
feat: Support default `tsconfig.json` as template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /src/fixtures/**/node_modules/.cache
 # /src/fixtures/**/.docz
 /src/fixtures/build/*/dist
+/src/fixtures/e2e/normal/.docz

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -80,10 +80,12 @@ export default async function(opts: IBabelOpts) {
 
   function getTSConfig() {
     const tsconfigPath = join(cwd, 'tsconfig.json');
+    const templateTsconfigPath = join(__dirname, '../template/tsconfig.json');
+
     if (existsSync(tsconfigPath)) {
       return JSON.parse(readFileSync(tsconfigPath, 'utf-8')).compilerOptions || {};
     } else {
-      return {};
+      return JSON.parse(readFileSync(templateTsconfigPath, 'utf-8')).compilerOptions || {};
     }
   }
 

--- a/src/build.ts
+++ b/src/build.ts
@@ -60,10 +60,15 @@ None format of ${chalk.cyan(
   }
   if (bundleOpts.entry) {
     const tsConfigPath = join(cwd, 'tsconfig.json')
-    if (Array.isArray(bundleOpts.entry) && bundleOpts.entry.some(isTypescriptFile)) {
-      assert.ok(existsSync(tsConfigPath), 'tsconfig.json is mandatory for typescript based project');
-    } else if (!Array.isArray(bundleOpts.entry) && isTypescriptFile(bundleOpts.entry)) {
-      assert.ok(existsSync(tsConfigPath), 'tsconfig.json is mandatory for typescript based project');
+    if (
+      !existsSync(tsConfigPath) && (
+        (Array.isArray(bundleOpts.entry) && bundleOpts.entry.some(isTypescriptFile)) ||
+        (!Array.isArray(bundleOpts.entry) && isTypescriptFile(bundleOpts.entry))
+      )
+    ) {
+      signale.info(
+        `Project using ${chalk.cyan('typescript')} but tsconfig.json not exists. Use default config.`
+      );
     }
   }
 }

--- a/src/fixtures/build/babel-typescript-template/.umirc.library.js
+++ b/src/fixtures/build/babel-typescript-template/.umirc.library.js
@@ -1,0 +1,5 @@
+
+export default {
+  cjs: { type: 'babel' },
+  esm: { type: 'babel' },
+};

--- a/src/fixtures/build/babel-typescript-template/expected/es/index.d.ts
+++ b/src/fixtures/build/babel-typescript-template/expected/es/index.d.ts
@@ -1,0 +1,5 @@
+interface IOpts {
+    foo: boolean;
+}
+export default function foo(opts: IOpts): string;
+export {};

--- a/src/fixtures/build/babel-typescript-template/expected/es/index.js
+++ b/src/fixtures/build/babel-typescript-template/expected/es/index.js
@@ -1,0 +1,3 @@
+export default function foo(opts) {
+  return opts.foo ? 'foo' : 'bar';
+}

--- a/src/fixtures/build/babel-typescript-template/expected/lib/index.d.ts
+++ b/src/fixtures/build/babel-typescript-template/expected/lib/index.d.ts
@@ -1,0 +1,5 @@
+interface IOpts {
+    foo: boolean;
+}
+export default function foo(opts: IOpts): string;
+export {};

--- a/src/fixtures/build/babel-typescript-template/expected/lib/index.js
+++ b/src/fixtures/build/babel-typescript-template/expected/lib/index.js
@@ -1,0 +1,10 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = foo;
+
+function foo(opts) {
+  return opts.foo ? 'foo' : 'bar';
+}

--- a/src/fixtures/build/babel-typescript-template/src/index.ts
+++ b/src/fixtures/build/babel-typescript-template/src/index.ts
@@ -1,0 +1,7 @@
+interface IOpts {
+  foo: boolean;
+}
+
+export default function foo(opts: IOpts): string {
+  return opts.foo ? 'foo' : 'bar';
+}

--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "module": "esnext",
+    "target": "esnext",
+    "moduleResolution": "node",
+    "jsx": "react"
+  }
+}


### PR DESCRIPTION
Provides default ts config if `tsconfig.json` not provided.

ref `rc-tools`:
* https://github.com/react-component/rc-tools/blob/master/lib/getTSCommonConfig.js
* https://github.com/react-component/rc-tools/blob/master/config/tsconfig.json

cc @chenshuai2144