### PR TITLE
fix: ignore pkg .DS_Store

### DIFF
--- a/src/build.test.ts
+++ b/src/build.test.ts
@@ -2,7 +2,7 @@ import { join } from 'path';
 import { existsSync, readdirSync, renameSync } from 'fs';
 import mkdirp from 'mkdirp';
 import rimraf from 'rimraf';
-import build from './build';
+import build, { EXCLUDE_DIR } from './build';
 
 describe('father build', () => {
   require('test-build-result')({
@@ -26,6 +26,7 @@ describe('father build', () => {
           mkdirp.sync(join(cwd, 'dist'));
           const pkgs = readdirSync(join(cwd, 'packages'));
           for (const pkg of pkgs) {
+            if (EXCLUDE_DIR.includes(pkg)) continue;
             renameSync(join(cwd, 'packages', pkg, 'dist'), join(cwd, 'dist', pkg));
           }
         }

--- a/src/build.test.ts
+++ b/src/build.test.ts
@@ -1,8 +1,8 @@
 import { join } from 'path';
-import { existsSync, readdirSync, renameSync } from 'fs';
+import { existsSync, readdirSync, renameSync, statSync } from 'fs';
 import mkdirp from 'mkdirp';
 import rimraf from 'rimraf';
-import build, { EXCLUDE_DIR } from './build';
+import build from './build';
 
 describe('father build', () => {
   require('test-build-result')({
@@ -26,7 +26,8 @@ describe('father build', () => {
           mkdirp.sync(join(cwd, 'dist'));
           const pkgs = readdirSync(join(cwd, 'packages'));
           for (const pkg of pkgs) {
-            if (EXCLUDE_DIR.includes(pkg)) continue;
+            const pkgPath = join(cwd, 'packages', pkg);
+            if (!statSync(pkgPath).isDirectory()) continue;
             renameSync(join(cwd, 'packages', pkg, 'dist'), join(cwd, 'dist', pkg));
           }
         }

--- a/src/build.ts
+++ b/src/build.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
 import { join } from 'path';
 import rimraf from 'rimraf';
 import * as assert from 'assert';
@@ -151,8 +151,6 @@ export async function build(opts: IOpts, extraOpts: IExtraBuildOpts = {}) {
     }
   }
 }
-// export for test case
-export const EXCLUDE_DIR = [ '.DS_Store' ];
 
 export async function buildForLerna(opts: IOpts) {
   const { cwd } = opts;
@@ -170,8 +168,8 @@ export async function buildForLerna(opts: IOpts) {
   for (const pkg of pkgs) {
     if (process.env.PACKAGE && pkg !== process.env.PACKAGE) continue;
     // build error when .DS_Store includes in packages root
-    if (EXCLUDE_DIR.includes(pkg)) continue;
     const pkgPath = join(opts.cwd, 'packages', pkg);
+    if (!statSync(pkgPath).isDirectory()) continue;
     assert.ok(
       existsSync(join(pkgPath, 'package.json')),
       `package.json not found in packages/${pkg}`,

--- a/src/build.ts
+++ b/src/build.ts
@@ -151,6 +151,8 @@ export async function build(opts: IOpts, extraOpts: IExtraBuildOpts = {}) {
     }
   }
 }
+// export for test case
+export const EXCLUDE_DIR = [ '.DS_Store' ];
 
 export async function buildForLerna(opts: IOpts) {
   const { cwd } = opts;
@@ -164,8 +166,11 @@ export async function buildForLerna(opts: IOpts) {
   const userConfig = getUserConfig({ cwd });
 
   const pkgs = readdirSync(join(opts.cwd, 'packages'));
+
   for (const pkg of pkgs) {
     if (process.env.PACKAGE && pkg !== process.env.PACKAGE) continue;
+    // build error when .DS_Store includes in packages root
+    if (EXCLUDE_DIR.includes(pkg)) continue;
     const pkgPath = join(opts.cwd, 'packages', pkg);
     assert.ok(
       existsSync(join(pkgPath, 'package.json')),


### PR DESCRIPTION
`.DS_Store` will exist in `packages` dir leading to a build error.

![image](https://user-images.githubusercontent.com/13595509/59397117-0218e780-8dbe-11e9-8d28-9b434bb98ee5.png)
