### PR TITLE
feat: Add reactConfig for udf react & reactDom url

### DIFF
--- a/packages/father/src/doc/docz-plugin-react-externals.ts
+++ b/packages/father/src/doc/docz-plugin-react-externals.ts
@@ -13,11 +13,12 @@ export default function() {
       const flag = process.env.NODE_ENV === 'development' ? 'development' : 'production.min';
       config.htmlContext.head = config.htmlContext.head || ({} as any);
       config.htmlContext.head.scripts = config.htmlContext.head.scripts || [];
+      const reactConfig = config.reactConfig || ({} as any);
       config.htmlContext.head.scripts.push({
-        src: `https://gw.alipayobjects.com/os/lib/react/16.8.6/umd/react.${flag}.js`,
+        src: reactConfig.react || `https://gw.alipayobjects.com/os/lib/react/16.8.6/umd/react.${flag}.js`,
       });
       config.htmlContext.head.scripts.push({
-        src: `https://gw.alipayobjects.com/os/lib/react-dom/16.8.6/umd/react-dom.${flag}.js`,
+        src: reactConfig.reactDom || `https://gw.alipayobjects.com/os/lib/react-dom/16.8.6/umd/react-dom.${flag}.js`,
       });
       return config;
     },


### PR DESCRIPTION
https://github.com/umijs/father/issues/15

增加`reactConfig`配置项，包含`react` & `reactDom`子项去自定义`react` & `react-dom`的url。如：
```
doc: {
  reactConfig: {
    react: xxxx,
    reactDom: xxxx
 }
}
```