### PR TITLE
feat:support rollup-plugin-copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /packages/father/src/fixtures/e2e/normal/.doc
 /packages/father/src/fixtures/e2e/normal/.docz
 /.changelog
+.history

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,12 @@ $ y bootstrap
 Link father globally.
 
 ```bash
-$ cd packages/father
+# link local father-build
+$ cd packages/father-build
+$ y link
+
+$ cd ../father
+$ y link father-build
 $ y link
 ```
 

--- a/README.md
+++ b/README.md
@@ -480,6 +480,21 @@ export default {
 
 则 `foo.js` 的 umd 配置为 `{ globals: { jquery: 'window.jQuery' }, name: 'foo' }`。
 
+#### copy
+```js
+export default {
+  copy: {
+    targets:[
+      {
+        src:'src/assets',
+        dest:'dist'
+      }
+    ]
+  }
+}
+```
+详细配置参考[rollup-plugin-copy](https://www.npmjs.com/package/rollup-plugin-copy)
+
 #### doc
 
 透传配置给 [docz][17]，可以有 `title`、`theme`、`themeConfig` 等。

--- a/packages/father-build/package.json
+++ b/packages/father-build/package.json
@@ -38,6 +38,7 @@
     "rollup": "1.15.1",
     "rollup-plugin-babel": "4.3.2",
     "rollup-plugin-commonjs": "10.0.0",
+    "rollup-plugin-copy": "^3.1.0",
     "rollup-plugin-json": "4.0.0",
     "rollup-plugin-node-resolve": "5.0.1",
     "rollup-plugin-postcss-umi": "2.0.3",

--- a/packages/father-build/src/getRollupConfig.ts
+++ b/packages/father-build/src/getRollupConfig.ts
@@ -7,6 +7,7 @@ import nodeResolve from 'rollup-plugin-node-resolve';
 import typescript from 'rollup-plugin-typescript2';
 import commonjs from 'rollup-plugin-commonjs';
 import postcss from 'rollup-plugin-postcss-umi';
+import copy from 'rollup-plugin-copy';
 import { ModuleFormat, RollupOptions } from 'rollup';
 import { camelCase } from 'lodash';
 import tempDir from 'temp-dir';
@@ -52,6 +53,7 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
     typescriptOpts,
     nodeResolveOpts = {},
     disableTypeCheck,
+    copy:copyOpts
   } = bundleOpts;
   const entryExt = extname(entry);
   const name = file || basename(entry, entryExt);
@@ -174,6 +176,7 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
       : []),
     babel(babelOpts),
     json(),
+    copy(copyOpts)
   ];
 
   switch (type) {

--- a/packages/father-build/src/schema.test.ts
+++ b/packages/father-build/src/schema.test.ts
@@ -21,6 +21,7 @@ const successValidates = {
   overridesByEntry: [{}],
   doc: [{}],
   typescriptOpts: [{}],
+  copy: [{}],
 };
 
 Object.keys(successValidates).forEach(key => {

--- a/packages/father-build/src/schema.ts
+++ b/packages/father-build/src/schema.ts
@@ -133,5 +133,8 @@ export default {
     typescriptOpts: {
       type: 'object',
     },
+    copy: {
+      type: 'object',
+    },
   },
 };

--- a/packages/father-build/src/types.d.ts
+++ b/packages/father-build/src/types.d.ts
@@ -75,6 +75,7 @@ export interface IBundleOptions {
   nodeResolveOpts?: {
     [value: string]: any;
   };
+  copy?: object;
 }
 
 export interface IOpts {


### PR DESCRIPTION
支持复制assets，在react组件开发中经常使用