### PR TITLE
fix: close watcher for SIGINT

### DIFF
--- a/packages/father-build/src/babel.ts
+++ b/packages/father-build/src/babel.ts
@@ -151,18 +151,21 @@ export default async function(opts: IBabelOpts) {
     ]).on('end', () => {
       if (watch) {
         signale.info('Start watch', srcPath);
-        chokidar
+        const watcher = chokidar
           .watch(srcPath, {
             ignoreInitial: true,
-          })
-          .on('all', (event, fullPath) => {
-            const relPath = fullPath.replace(srcPath, '');
-            signale.info(`[${event}] ${join(srcPath, relPath)}`);
-            if (!existsSync(fullPath)) return;
-            if (statSync(fullPath).isFile()) {
-              createStream([fullPath]);
-            }
           });
+        watcher.on('all', (event, fullPath) => {
+          const relPath = fullPath.replace(srcPath, '');
+          signale.info(`[${event}] ${join(srcPath, relPath)}`);
+          if (!existsSync(fullPath)) return;
+          if (statSync(fullPath).isFile()) {
+            createStream([fullPath]);
+          }
+        });
+        process.once('SIGINT', () => {
+          watcher.close();
+        });
       }
       resolve();
     });

--- a/packages/father-build/src/rollup.ts
+++ b/packages/father-build/src/rollup.ts
@@ -38,6 +38,9 @@ async function build(entry: string, opts: IRollupOpts) {
           signale.info(`[${type}] Rebuild since file changed`);
         }
       });
+      process.once('SIGINT', () => {
+        watcher.close();
+      });
     } else {
       const { output, ...input } = rollupConfig;
       const bundle = await rollup(input); // eslint-disable-line


### PR DESCRIPTION
修复 umi 下执行 `y ui:build -w` 后按 Command+C，进程不会退出的问题。
