### PR TITLE
chore: Add env for storybook usage

### DIFF
--- a/packages/father/src/doc/storybook.ts
+++ b/packages/father/src/doc/storybook.ts
@@ -13,6 +13,8 @@ export function devOrBuild({ cwd, cmd, DOC_PATH, args = {}, }: Partial<DocProps>
     });
   } else {
     // Dev mode
+    process.env.NODE_ENV = 'development';
+
     return storybook({
       mode: 'dev',
       port: args.port || '9001',


### PR DESCRIPTION
Storybook read the env variable as build variable. We need set this for `dev` mode.