### PR TITLE
fix(father): failed to resolve module in Windows

### DIFF
--- a/packages/father/package.json
+++ b/packages/father/package.json
@@ -54,6 +54,7 @@
     "rc-source-loader": "^1.0.2",
     "react-markdown": "^4.0.8",
     "signale": "1.4.0",
+    "slash2": "^2.0.0",
     "staged-git-files": "^1.2.0",
     "storybook-addon-source": "^1.0.7",
     "umi-test": "^1.5.10",

--- a/packages/father/src/doc/storybook-generator.ts
+++ b/packages/father/src/doc/storybook-generator.ts
@@ -1,6 +1,7 @@
 import { existsSync, ensureDirSync, writeFileSync, readFileSync } from 'fs-extra';
 import { join } from 'path';
 import { sync } from 'glob';
+import winPath from 'slash2';
 
 const STORYBOOK_FOLDER = '.storybook';
 
@@ -90,7 +91,7 @@ ${addString.join('\n')}
 `;
 
   // Write files
-  const entryPath = join(tempStorybookPath, 'index.js');
+  const entryPath = winPath(join(tempStorybookPath, 'index.js'));
   ensureDirSync(tempStorybookPath);
   writeFileSync(entryPath, fileContent, 'utf8');
 
@@ -157,7 +158,7 @@ configure(loadStories, module);`;
   // ===================================================================
   const webpackContent = `
 module.exports = function(...args) {
-  return require('${join(__dirname, 'storybook-webpack')}')(...args);
+  return require('${winPath(join(__dirname, 'storybook-webpack'))}')(...args);
 };
 `;
   writeFileSync(join(tempStorybookPath, 'webpack.config.js'), webpackContent);


### PR DESCRIPTION
Fix the bug that fail to use `storybook` in Windows.
Related issues: https://github.com/umijs/father/issues/86