### PR TITLE
feat: bottom-up search file `tsconfig.json`

### DIFF
--- a/packages/father-build/src/getRollupConfig.ts
+++ b/packages/father-build/src/getRollupConfig.ts
@@ -167,9 +167,8 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
             // @see https://github.com/ezolenko/rollup-plugin-typescript2/issues/105
             objectHashIgnoreUnknownHack: true,
             cacheRoot: `${tempDir}/.rollup_plugin_typescript2_cache`,
-            // TODO: 支持往上找 tsconfig.json
             // 比如 lerna 的场景不需要每个 package 有个 tsconfig.json
-            tsconfig: join(cwd, 'tsconfig.json'),
+            tsconfig: 'tsconfig.json',
             tsconfigDefaults: {
               compilerOptions: {
                 // Generate declaration files by default


### PR DESCRIPTION
`rollup-plugin-typescript2` find out `tsconfig` via method [findConfigFile](https://github.com/microsoft/TypeScript/blob/2d96a163d1a666e7b156c5597f3419ff8b560864/src/compiler/program.ts#L4), supporting bottom up search by default.