### PR TITLE
feat: supported `umd.sourcemap` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ cjs 为 `rollup` 或 `babel` 时，等同于配置了 `{ type: "rollup" | "babel
 
 是否输出 umd 格式，以及指定 umd 的相关配置。
 
-* Type: `{ globals, name, minFile, file } | false`
+* Type: `{ globals, name, minFile, file, sourcemap } | false`
 * Default: `false`
 
 #### umd.globals
@@ -262,6 +262,13 @@ cjs 为 `rollup` 或 `babel` 时，等同于配置了 `{ type: "rollup" | "babel
 指定 umd 的输出文件名。
 
 - Type: `string`
+- Default: `undefined`
+
+#### umd.sourcemap
+
+是否同步输出sourcemap。
+
+- Type: `boolean`
 - Default: `undefined`
 
 #### autoprefixer

--- a/packages/father-build/src/fixtures/build/rollup-umd-sourcemap/.fatherrc.js
+++ b/packages/father-build/src/fixtures/build/rollup-umd-sourcemap/.fatherrc.js
@@ -1,0 +1,8 @@
+
+export default {
+  umd: {
+    minFile: false,
+    name: 'foo',
+    sourcemap: true,
+  },
+}

--- a/packages/father-build/src/fixtures/build/rollup-umd-sourcemap/expected/index.umd.js
+++ b/packages/father-build/src/fixtures/build/rollup-umd-sourcemap/expected/index.umd.js
@@ -1,0 +1,14 @@
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+  typeof define === 'function' && define.amd ? define(factory) :
+  (global = global || self, global.foo = factory());
+}(this, function () { 'use strict';
+
+  function index () {
+    return 'foo';
+  }
+
+  return index;
+
+}));
+//# sourceMappingURL=index.umd.js.map

--- a/packages/father-build/src/fixtures/build/rollup-umd-sourcemap/expected/index.umd.js.map
+++ b/packages/father-build/src/fixtures/build/rollup-umd-sourcemap/expected/index.umd.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"index.umd.js","sources":["../src/index.js"],"sourcesContent":["\nexport default function () {\n  return 'foo';\n}\n"],"names":[],"mappings":";;;;;;EACe,kBAAY;EACzB,SAAO,KAAP;EACD;;;;;;;;"}

--- a/packages/father-build/src/fixtures/build/rollup-umd-sourcemap/src/index.js
+++ b/packages/father-build/src/fixtures/build/rollup-umd-sourcemap/src/index.js
@@ -1,0 +1,4 @@
+
+export default function () {
+  return 'foo';
+}

--- a/packages/father-build/src/getRollupConfig.ts
+++ b/packages/father-build/src/getRollupConfig.ts
@@ -266,6 +266,7 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
           input,
           output: {
             format,
+            sourcemap: umd && umd.sourcemap,
             file: join(cwd, `dist/${(umd && umd.file) || `${name}.umd`}.js`),
             globals: umd && umd.globals,
             name: (umd && umd.name) || (pkg.name && camelCase(basename(pkg.name))),
@@ -286,6 +287,7 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
                 input,
                 output: {
                   format,
+                  sourcemap: umd && umd.sourcemap,
                   file: join(cwd, `dist/${(umd && umd.file) || `${name}.umd`}.min.js`),
                   globals: umd && umd.globals,
                   name: (umd && umd.name) || (pkg.name && camelCase(basename(pkg.name))),

--- a/packages/father-build/src/schema.test.ts
+++ b/packages/father-build/src/schema.test.ts
@@ -8,7 +8,7 @@ const successValidates = {
   file: ['a'],
   esm: [false, true, { type: 'rollup' }, { type: 'babel' }, { file: 'a' }, { mjs: true }],
   cjs: [false, true, { type: 'rollup' }, { type: 'babel' }, { file: 'a' }],
-  umd: [{ globals: {} }, { file: 'a' }, { name: 'a' }, { minFile: false }, { minFile: true }],
+  umd: [{ globals: {} }, { file: 'a' }, { name: 'a' }, { minFile: false }, { minFile: true }, { sourcemap: true }],
   extraBabelPlugins: [[]],
   extraBabelPresets: [[]],
   extraPostCSSPlugins: [[]],

--- a/packages/father-build/src/schema.ts
+++ b/packages/father-build/src/schema.ts
@@ -60,6 +60,7 @@ export default {
             file: noEmptyStr,
             name: noEmptyStr,
             minFile: { type: 'boolean' },
+            sourcemap: { type: 'boolean' },
           },
         },
       ],

--- a/packages/father-build/src/types.d.ts
+++ b/packages/father-build/src/types.d.ts
@@ -29,6 +29,7 @@ interface IUmd {
   name?: string;
   minFile?: boolean;
   file?: string;
+  sourcemap?: boolean;
 }
 
 export interface IBundleOptions {


### PR DESCRIPTION
umd格式，很多时候是用来单独在浏览器中运行的，因此添加sourcemap选项，以便调试代码