### PR TITLE
fix: parse tsconfig.josn error

### DIFF
--- a/packages/father-build/src/fixtures/build/babel-typescript/tsconfig.json
+++ b/packages/father-build/src/fixtures/build/babel-typescript/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    // tsconfig is not valid josn file
     "target": "esnext",
     "moduleResolution": "node",
     "jsx": "preserve",

--- a/packages/father-build/src/schema.test.ts
+++ b/packages/father-build/src/schema.test.ts
@@ -23,7 +23,7 @@ const successValidates = {
   overridesByEntry: [{}],
   doc: [{}],
   typescriptOpts: [{}],
-  pkgs: ['a'],
+  pkgs: [[]],
 };
 
 Object.keys(successValidates).forEach(key => {


### PR DESCRIPTION
- `tsconfig.json` 不是严格的json, `tsc --init`生成的默认 tsconfig.josn 就带有很多注释。
这里将JSON.parse 换成ts自带的api，保证兼容。
- 另外修复一个小的测试bug。