### PR TITLE
chore: resolve the absolute path of plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,11 +342,14 @@ export default {
 ```js
 export default {
   extraBabelPlugins: [
-    ['babel-plugin-import', {
-      libraryName: 'antd',
-      libraryDirectory: 'es',
-      style: true,
-    }],
+    [
+      require.resolve('babel-plugin-import'),
+      {
+        libraryName: '@alifd/next',
+        libraryDirectory: 'es',
+        style: true,
+      },
+    ],
   ],
 };
 ```


### PR DESCRIPTION
没有 require.resolve，会一直找不到对应 plugin，导致 `extraBabelPlugins` 配置不生效。