### PR TITLE
feat: support babel runtime version

### DIFF
--- a/packages/father-build/src/fixtures/build/babel-runtimeHelpers/expected/es/index.js
+++ b/packages/father-build/src/fixtures/build/babel-runtimeHelpers/expected/es/index.js
@@ -1,19 +1,21 @@
+import _objectSpread from "@babel/runtime/helpers/esm/objectSpread2";
 import _classCallCheck from "@babel/runtime/helpers/esm/classCallCheck";
 import _createClass from "@babel/runtime/helpers/esm/createClass";
 
-var A = /*#__PURE__*/ (function() {
+var A = /*#__PURE__*/function () {
   function A() {
     _classCallCheck(this, A);
   }
 
-  _createClass(A, [
-    {
-      key: "foo",
-      value: function foo() {}
-    }
-  ]);
+  _createClass(A, [{
+    key: "foo",
+    value: function foo() {}
+  }]);
 
   return A;
-})();
+}();
 
 new A().foo();
+var a = {};
+
+var b = _objectSpread({}, a);

--- a/packages/father-build/src/fixtures/build/babel-runtimeHelpers/expected/lib/index.js
+++ b/packages/father-build/src/fixtures/build/babel-runtimeHelpers/expected/lib/index.js
@@ -2,26 +2,24 @@
 
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
 
-var _classCallCheck2 = _interopRequireDefault(
-  require("@babel/runtime/helpers/classCallCheck")
-);
+var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread2"));
 
-var _createClass2 = _interopRequireDefault(
-  require("@babel/runtime/helpers/createClass")
-);
+var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
 
-var A = /*#__PURE__*/ (function() {
+var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
+
+var A = /*#__PURE__*/function () {
   function A() {
     (0, _classCallCheck2.default)(this, A);
   }
 
-  (0, _createClass2.default)(A, [
-    {
-      key: "foo",
-      value: function foo() {}
-    }
-  ]);
+  (0, _createClass2.default)(A, [{
+    key: "foo",
+    value: function foo() {}
+  }]);
   return A;
-})();
+}();
 
 new A().foo();
+var a = {};
+var b = (0, _objectSpread2.default)({}, a);

--- a/packages/father-build/src/fixtures/build/babel-runtimeHelpers/package.json
+++ b/packages/father-build/src/fixtures/build/babel-runtimeHelpers/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@babel/runtime": "0.1.0"
+    "@babel/runtime": "7.10.4"
   }
 }

--- a/packages/father-build/src/fixtures/build/babel-runtimeHelpers/src/index.js
+++ b/packages/father-build/src/fixtures/build/babel-runtimeHelpers/src/index.js
@@ -4,3 +4,6 @@ class A {
 }
 
 (new A()).foo();
+
+const a = {};
+const b = {...a};

--- a/packages/father-build/src/fixtures/build/babel-syntax/expected/index.esm.js
+++ b/packages/father-build/src/fixtures/build/babel-syntax/expected/index.esm.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 
 function _classCallCheck(instance, Constructor) {
   if (!(instance instanceof Constructor)) {
@@ -42,18 +42,18 @@ function _objectWithoutProperties(source, excluded) {
   return target;
 }
 
-function a() {
-  alert("a");
+function a () {
+  alert('a');
 }
 
 function b1() {
-  alert("b1");
+  alert('b1');
 }
 function b2() {
-  alert("b2");
+  alert('b2');
 }
 
-var b = /*#__PURE__*/ Object.freeze({
+var b = /*#__PURE__*/Object.freeze({
   __proto__: null,
   b1: b1,
   b2: b2
@@ -62,26 +62,23 @@ var b = /*#__PURE__*/ Object.freeze({
 var _class;
 // babel-plugin-react-require
 var Foo = function Foo() {
-  return /*#__PURE__*/ React.createElement("div", null);
+  return /*#__PURE__*/React.createElement("div", null);
 }; // Don't support multiple chunks for now
 // @babel/plugin-syntax-dynamic-import
 // import('./a');
 // object-rest-spread
 
 var _bar = bar,
-  foo = _bar.foo,
-  z = _objectWithoutProperties(_bar, ["foo"]);
+    foo = _bar.foo,
+    z = _objectWithoutProperties(_bar, ["foo"]);
 
 console.log(z); // @babel/plugin-proposal-decorators + class
 
-var A =
-  foo(
-    (_class = function A() {
-      _classCallCheck(this, A);
-    })
-  ) || _class; // export default from
+var A = foo(_class = function A() {
+  _classCallCheck(this, A);
+}) || _class; // export default from
 
-var a$1 = x > 10 ? "big" : "small";
+var a$1 = x > 10 ? 'big' : 'small';
 console.log(a$1); // export namespace from
 
 export { A, Foo, a, b };

--- a/packages/father-build/src/fixtures/build/rollup-resolve-jsx/expected/index.esm.js
+++ b/packages/father-build/src/fixtures/build/rollup-resolve-jsx/expected/index.esm.js
@@ -1,11 +1,11 @@
-import React from "react";
+import React from 'react';
 
-var Foo = function() {
-  return /*#__PURE__*/ React.createElement("h1", null, "Foo");
-};
+var Foo = (function () {
+  return /*#__PURE__*/React.createElement("h1", null, "Foo");
+});
 
-var index = function() {
-  return /*#__PURE__*/ React.createElement(Foo, null);
-};
+var index = (function () {
+  return /*#__PURE__*/React.createElement(Foo, null);
+});
 
 export default index;

--- a/packages/father-build/src/fixtures/build/rollup-runtimeHelpers/expected/index.esm.js
+++ b/packages/father-build/src/fixtures/build/rollup-runtimeHelpers/expected/index.esm.js
@@ -1,19 +1,17 @@
-import _classCallCheck from "@babel/runtime/helpers/esm/classCallCheck";
-import _createClass from "@babel/runtime/helpers/esm/createClass";
+import _classCallCheck from '@babel/runtime/helpers/esm/classCallCheck';
+import _createClass from '@babel/runtime/helpers/esm/createClass';
 
-var A = /*#__PURE__*/ (function() {
+var A = /*#__PURE__*/function () {
   function A() {
     _classCallCheck(this, A);
   }
 
-  _createClass(A, [
-    {
-      key: "foo",
-      value: function foo() {}
-    }
-  ]);
+  _createClass(A, [{
+    key: "foo",
+    value: function foo() {}
+  }]);
 
   return A;
-})();
+}();
 
 new A().foo();

--- a/packages/father-build/src/fixtures/build/rollup-runtimeHelpers/expected/index.js
+++ b/packages/father-build/src/fixtures/build/rollup-runtimeHelpers/expected/index.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 function _classCallCheck(instance, Constructor) {
   if (!(instance instanceof Constructor)) {
@@ -22,19 +22,17 @@ function _createClass(Constructor, protoProps, staticProps) {
   return Constructor;
 }
 
-var A = /*#__PURE__*/ (function() {
+var A = /*#__PURE__*/function () {
   function A() {
     _classCallCheck(this, A);
   }
 
-  _createClass(A, [
-    {
-      key: "foo",
-      value: function foo() {}
-    }
-  ]);
+  _createClass(A, [{
+    key: "foo",
+    value: function foo() {}
+  }]);
 
   return A;
-})();
+}();
 
 new A().foo();

--- a/packages/father-build/src/fixtures/build/rollup-svgr/dist/index.esm.js
+++ b/packages/father-build/src/fixtures/build/rollup-svgr/dist/index.esm.js
@@ -1,51 +1,22 @@
-import React from "react";
+import React from 'react';
 
-function _extends() {
-  _extends =
-    Object.assign ||
-    function(target) {
-      for (var i = 1; i < arguments.length; i++) {
-        var source = arguments[i];
-        for (var key in source) {
-          if (Object.prototype.hasOwnProperty.call(source, key)) {
-            target[key] = source[key];
-          }
-        }
-      }
-      return target;
-    };
-  return _extends.apply(this, arguments);
-}
+function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
-var _ref = /*#__PURE__*/ React.createElement(
-  "defs",
-  null,
-  /*#__PURE__*/ React.createElement("style", null)
-);
+var _ref = /*#__PURE__*/React.createElement("defs", null, /*#__PURE__*/React.createElement("style", null));
 
-var _ref2 = /*#__PURE__*/ React.createElement("path", {
-  d:
-    "M656 512h160c8.8 0 16-7.2 16-16v-96c0-8.8-7.2-16-16-16H656c-8.8 0-16 7.2-16 16v22H346V320h86c8.8 0 16-7.2 16-16v-96c0-8.8-7.2-16-16-16H208c-8.8 0-16 7.2-16 16v96c0 8.8 7.2 16 16 16h86v378c0 17.7 14.3 32 32 32h314v22c0 8.8 7.2 16 16 16h160c8.8 0 16-7.2 16-16v-96c0-8.8-7.2-16-16-16H656c-8.8 0-16 7.2-16 16v22H346V474h294v22c0 8.8 7.2 16 16 16z"
+var _ref2 = /*#__PURE__*/React.createElement("path", {
+  d: "M656 512h160c8.8 0 16-7.2 16-16v-96c0-8.8-7.2-16-16-16H656c-8.8 0-16 7.2-16 16v22H346V320h86c8.8 0 16-7.2 16-16v-96c0-8.8-7.2-16-16-16H208c-8.8 0-16 7.2-16 16v96c0 8.8 7.2 16 16 16h86v378c0 17.7 14.3 32 32 32h314v22c0 8.8 7.2 16 16 16h160c8.8 0 16-7.2 16-16v-96c0-8.8-7.2-16-16-16H656c-8.8 0-16 7.2-16 16v22H346V474h294v22c0 8.8 7.2 16 16 16z"
 });
 
 var SvgMenu = function SvgMenu(props) {
-  return /*#__PURE__*/ React.createElement(
-    "svg",
-    _extends(
-      {
-        className: "menu_svg__icon",
-        viewBox: "0 0 1024 1024",
-        width: 200,
-        height: 200
-      },
-      props
-    ),
-    _ref,
-    _ref2
-  );
+  return /*#__PURE__*/React.createElement("svg", _extends({
+    className: "menu_svg__icon",
+    viewBox: "0 0 1024 1024",
+    width: 200,
+    height: 200
+  }, props), _ref, _ref2);
 };
 
-var svgUrl =
-  "data:image/svg+xml,%3C%3Fxml%20version%3D%221.0%22%20standalone%3D%22no%22%3F%3E%3C!DOCTYPE%20svg%20PUBLIC%20%22-%2F%2FW3C%2F%2FDTD%20SVG%201.1%2F%2FEN%22%20%20%22http%3A%2F%2Fwww.w3.org%2FGraphics%2FSVG%2F1.1%2FDTD%2Fsvg11.dtd%22%3E%3Csvg%20t%3D%221558949630117%22%20class%3D%22icon%22%20style%3D%22%22%20viewBox%3D%220%200%201024%201024%22%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20%20%20%20%20p-id%3D%2233994%22%20%20%20%20%20width%3D%22200%22%20height%3D%22200%22%3E%20%20%3Cdefs%3E%20%20%20%20%3Cstyle%20type%3D%22text%2Fcss%22%3E%3C%2Fstyle%3E%20%20%3C%2Fdefs%3E%20%20%3Cpath%20%20%20%20d%3D%22M656%20512h160c8.8%200%2016-7.2%2016-16v-96c0-8.8-7.2-16-16-16H656c-8.8%200-16%207.2-16%2016v22H346V320h86c8.8%200%2016-7.2%2016-16v-96c0-8.8-7.2-16-16-16H208c-8.8%200-16%207.2-16%2016v96c0%208.8%207.2%2016%2016%2016h86v378c0%2017.7%2014.3%2032%2032%2032h314v22c0%208.8%207.2%2016%2016%2016h160c8.8%200%2016-7.2%2016-16v-96c0-8.8-7.2-16-16-16H656c-8.8%200-16%207.2-16%2016v22H346V474h294v22c0%208.8%207.2%2016%2016%2016z%22%20%20%20%20p-id%3D%2233995%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E";
+var svgUrl = "data:image/svg+xml,%3C%3Fxml%20version%3D%221.0%22%20standalone%3D%22no%22%3F%3E%3C!DOCTYPE%20svg%20PUBLIC%20%22-%2F%2FW3C%2F%2FDTD%20SVG%201.1%2F%2FEN%22%20%20%22http%3A%2F%2Fwww.w3.org%2FGraphics%2FSVG%2F1.1%2FDTD%2Fsvg11.dtd%22%3E%3Csvg%20t%3D%221558949630117%22%20class%3D%22icon%22%20style%3D%22%22%20viewBox%3D%220%200%201024%201024%22%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20%20%20%20%20p-id%3D%2233994%22%20%20%20%20%20width%3D%22200%22%20height%3D%22200%22%3E%20%20%3Cdefs%3E%20%20%20%20%3Cstyle%20type%3D%22text%2Fcss%22%3E%3C%2Fstyle%3E%20%20%3C%2Fdefs%3E%20%20%3Cpath%20%20%20%20d%3D%22M656%20512h160c8.8%200%2016-7.2%2016-16v-96c0-8.8-7.2-16-16-16H656c-8.8%200-16%207.2-16%2016v22H346V320h86c8.8%200%2016-7.2%2016-16v-96c0-8.8-7.2-16-16-16H208c-8.8%200-16%207.2-16%2016v96c0%208.8%207.2%2016%2016%2016h86v378c0%2017.7%2014.3%2032%2032%2032h314v22c0%208.8%207.2%2016%2016%2016h160c8.8%200%2016-7.2%2016-16v-96c0-8.8-7.2-16-16-16H656c-8.8%200-16%207.2-16%2016v22H346V474h294v22c0%208.8%207.2%2016%2016%2016z%22%20%20%20%20p-id%3D%2233995%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E";
 
-console.log(svgUrl, /*#__PURE__*/ React.createElement(SvgMenu, null));
+console.log(svgUrl, /*#__PURE__*/React.createElement(SvgMenu, null));

--- a/packages/father-build/src/fixtures/build/rollup-svgr/expected/index.esm.js
+++ b/packages/father-build/src/fixtures/build/rollup-svgr/expected/index.esm.js
@@ -1,51 +1,22 @@
-import React from "react";
+import React from 'react';
 
-function _extends() {
-  _extends =
-    Object.assign ||
-    function(target) {
-      for (var i = 1; i < arguments.length; i++) {
-        var source = arguments[i];
-        for (var key in source) {
-          if (Object.prototype.hasOwnProperty.call(source, key)) {
-            target[key] = source[key];
-          }
-        }
-      }
-      return target;
-    };
-  return _extends.apply(this, arguments);
-}
+function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
-var _ref = /*#__PURE__*/ React.createElement(
-  "defs",
-  null,
-  /*#__PURE__*/ React.createElement("style", null)
-);
+var _ref = /*#__PURE__*/React.createElement("defs", null, /*#__PURE__*/React.createElement("style", null));
 
-var _ref2 = /*#__PURE__*/ React.createElement("path", {
-  d:
-    "M656 512h160c8.8 0 16-7.2 16-16v-96c0-8.8-7.2-16-16-16H656c-8.8 0-16 7.2-16 16v22H346V320h86c8.8 0 16-7.2 16-16v-96c0-8.8-7.2-16-16-16H208c-8.8 0-16 7.2-16 16v96c0 8.8 7.2 16 16 16h86v378c0 17.7 14.3 32 32 32h314v22c0 8.8 7.2 16 16 16h160c8.8 0 16-7.2 16-16v-96c0-8.8-7.2-16-16-16H656c-8.8 0-16 7.2-16 16v22H346V474h294v22c0 8.8 7.2 16 16 16z"
+var _ref2 = /*#__PURE__*/React.createElement("path", {
+  d: "M656 512h160c8.8 0 16-7.2 16-16v-96c0-8.8-7.2-16-16-16H656c-8.8 0-16 7.2-16 16v22H346V320h86c8.8 0 16-7.2 16-16v-96c0-8.8-7.2-16-16-16H208c-8.8 0-16 7.2-16 16v96c0 8.8 7.2 16 16 16h86v378c0 17.7 14.3 32 32 32h314v22c0 8.8 7.2 16 16 16h160c8.8 0 16-7.2 16-16v-96c0-8.8-7.2-16-16-16H656c-8.8 0-16 7.2-16 16v22H346V474h294v22c0 8.8 7.2 16 16 16z"
 });
 
 var SvgMenu = function SvgMenu(props) {
-  return /*#__PURE__*/ React.createElement(
-    "svg",
-    _extends(
-      {
-        className: "menu_svg__icon",
-        viewBox: "0 0 1024 1024",
-        width: 200,
-        height: 200
-      },
-      props
-    ),
-    _ref,
-    _ref2
-  );
+  return /*#__PURE__*/React.createElement("svg", _extends({
+    className: "menu_svg__icon",
+    viewBox: "0 0 1024 1024",
+    width: 200,
+    height: 200
+  }, props), _ref, _ref2);
 };
 
-var svgUrl =
-  "data:image/svg+xml,%3C%3Fxml%20version%3D%221.0%22%20standalone%3D%22no%22%3F%3E%3C!DOCTYPE%20svg%20PUBLIC%20%22-%2F%2FW3C%2F%2FDTD%20SVG%201.1%2F%2FEN%22%20%20%22http%3A%2F%2Fwww.w3.org%2FGraphics%2FSVG%2F1.1%2FDTD%2Fsvg11.dtd%22%3E%3Csvg%20t%3D%221558949630117%22%20class%3D%22icon%22%20style%3D%22%22%20viewBox%3D%220%200%201024%201024%22%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20%20%20%20%20p-id%3D%2233994%22%20%20%20%20%20width%3D%22200%22%20height%3D%22200%22%3E%20%20%3Cdefs%3E%20%20%20%20%3Cstyle%20type%3D%22text%2Fcss%22%3E%3C%2Fstyle%3E%20%20%3C%2Fdefs%3E%20%20%3Cpath%20%20%20%20d%3D%22M656%20512h160c8.8%200%2016-7.2%2016-16v-96c0-8.8-7.2-16-16-16H656c-8.8%200-16%207.2-16%2016v22H346V320h86c8.8%200%2016-7.2%2016-16v-96c0-8.8-7.2-16-16-16H208c-8.8%200-16%207.2-16%2016v96c0%208.8%207.2%2016%2016%2016h86v378c0%2017.7%2014.3%2032%2032%2032h314v22c0%208.8%207.2%2016%2016%2016h160c8.8%200%2016-7.2%2016-16v-96c0-8.8-7.2-16-16-16H656c-8.8%200-16%207.2-16%2016v22H346V474h294v22c0%208.8%207.2%2016%2016%2016z%22%20%20%20%20p-id%3D%2233995%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E";
+var svgUrl = "data:image/svg+xml,%3C%3Fxml%20version%3D%221.0%22%20standalone%3D%22no%22%3F%3E%3C!DOCTYPE%20svg%20PUBLIC%20%22-%2F%2FW3C%2F%2FDTD%20SVG%201.1%2F%2FEN%22%20%20%22http%3A%2F%2Fwww.w3.org%2FGraphics%2FSVG%2F1.1%2FDTD%2Fsvg11.dtd%22%3E%3Csvg%20t%3D%221558949630117%22%20class%3D%22icon%22%20style%3D%22%22%20viewBox%3D%220%200%201024%201024%22%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20%20%20%20%20p-id%3D%2233994%22%20%20%20%20%20width%3D%22200%22%20height%3D%22200%22%3E%20%20%3Cdefs%3E%20%20%20%20%3Cstyle%20type%3D%22text%2Fcss%22%3E%3C%2Fstyle%3E%20%20%3C%2Fdefs%3E%20%20%3Cpath%20%20%20%20d%3D%22M656%20512h160c8.8%200%2016-7.2%2016-16v-96c0-8.8-7.2-16-16-16H656c-8.8%200-16%207.2-16%2016v22H346V320h86c8.8%200%2016-7.2%2016-16v-96c0-8.8-7.2-16-16-16H208c-8.8%200-16%207.2-16%2016v96c0%208.8%207.2%2016%2016%2016h86v378c0%2017.7%2014.3%2032%2032%2032h314v22c0%208.8%207.2%2016%2016%2016h160c8.8%200%2016-7.2%2016-16v-96c0-8.8-7.2-16-16-16H656c-8.8%200-16%207.2-16%2016v22H346V474h294v22c0%208.8%207.2%2016%2016%2016z%22%20%20%20%20p-id%3D%2233995%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E";
 
-console.log(svgUrl, /*#__PURE__*/ React.createElement(SvgMenu, null));
+console.log(svgUrl, /*#__PURE__*/React.createElement(SvgMenu, null));

--- a/packages/father-build/src/getBabelConfig.ts
+++ b/packages/father-build/src/getBabelConfig.ts
@@ -79,7 +79,10 @@ export default function(opts: IGetBabelConfigOpts) {
         [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
         [require.resolve('@babel/plugin-proposal-class-properties'), { loose: true }],
         ...(runtimeHelpers
-          ? [[require.resolve('@babel/plugin-transform-runtime'), { useESModules: isBrowser && (type === 'esm') }]]
+          ? [[require.resolve('@babel/plugin-transform-runtime'), {
+            useESModules: isBrowser && (type === 'esm'),
+            version: require('@babel/runtime/package.json').version,
+          }]]
           : []),
         ...(process.env.COVERAGE
             ? [require.resolve('babel-plugin-istanbul')]

--- a/packages/father/src/fixtures/e2e/normal/dist/index.esm.js
+++ b/packages/father/src/fixtures/e2e/normal/dist/index.esm.js
@@ -1,18 +1,16 @@
-import React from "react";
+import React from 'react';
 
 function styleInject(css, ref) {
-  if (ref === void 0) ref = {};
+  if ( ref === void 0 ) ref = {};
   var insertAt = ref.insertAt;
 
-  if (!css || typeof document === "undefined") {
-    return;
-  }
+  if (!css || typeof document === 'undefined') { return; }
 
-  var head = document.head || document.getElementsByTagName("head")[0];
-  var style = document.createElement("style");
-  style.type = "text/css";
+  var head = document.head || document.getElementsByTagName('head')[0];
+  var style = document.createElement('style');
+  style.type = 'text/css';
 
-  if (insertAt === "top") {
+  if (insertAt === 'top') {
     if (head.firstChild) {
       head.insertBefore(style, head.firstChild);
     } else {
@@ -35,17 +33,13 @@ styleInject(css);
 var css$1 = ".b {\n  border: 2px solid #ccc;\n}\n";
 styleInject(css$1);
 
-function index(props) {
-  return /*#__PURE__*/ React.createElement(
-    "button",
-    {
-      className: "g b",
-      style: {
-        fontSize: props.size === "large" ? 40 : 20
-      }
-    },
-    props.children
-  );
+function index (props) {
+  return /*#__PURE__*/React.createElement("button", {
+    className: "g b",
+    style: {
+      fontSize: props.size === 'large' ? 40 : 20
+    }
+  }, props.children);
 }
 
 export { index as button };

--- a/packages/father/src/fixtures/e2e/normal/expected/index.esm.js
+++ b/packages/father/src/fixtures/e2e/normal/expected/index.esm.js
@@ -1,18 +1,16 @@
-import React from "react";
+import React from 'react';
 
 function styleInject(css, ref) {
-  if (ref === void 0) ref = {};
+  if ( ref === void 0 ) ref = {};
   var insertAt = ref.insertAt;
 
-  if (!css || typeof document === "undefined") {
-    return;
-  }
+  if (!css || typeof document === 'undefined') { return; }
 
-  var head = document.head || document.getElementsByTagName("head")[0];
-  var style = document.createElement("style");
-  style.type = "text/css";
+  var head = document.head || document.getElementsByTagName('head')[0];
+  var style = document.createElement('style');
+  style.type = 'text/css';
 
-  if (insertAt === "top") {
+  if (insertAt === 'top') {
     if (head.firstChild) {
       head.insertBefore(style, head.firstChild);
     } else {
@@ -35,17 +33,13 @@ styleInject(css);
 var css$1 = ".b {\n  border: 2px solid #ccc;\n}\n";
 styleInject(css$1);
 
-function index(props) {
-  return /*#__PURE__*/ React.createElement(
-    "button",
-    {
-      className: "g b",
-      style: {
-        fontSize: props.size === "large" ? 40 : 20
-      }
-    },
-    props.children
-  );
+function index (props) {
+  return /*#__PURE__*/React.createElement("button", {
+    className: "g b",
+    style: {
+      fontSize: props.size === 'large' ? 40 : 20
+    }
+  }, props.children);
 }
 
 export { index as button };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/father/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/father/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

close https://github.com/umijs/father/issues/224

参考 https://github.com/babel/babel/issues/10261 。

开启 [version](https://www.babeljs.cn/docs/babel-plugin-transform-runtime#version) 参数，解决 `ownKeys` 和 `_objectSpread` 没有走 @babel/runtime 的问题。比如：https://unpkg.com/browse/rc-select@11.1.0/es/generate.js

