### PR TITLE
fix(): 解决father-build babel模式构建时会受外部babel.config.js影响导致babelOpts失效的问题

### DIFF
--- a/packages/father-build/src/babel.ts
+++ b/packages/father-build/src/babel.ts
@@ -92,7 +92,9 @@ export default async function(opts: IBabelOpts) {
 
     return babel.transform(file.contents, {
       ...babelOpts,
-      filename: file.path
+      filename: file.path,
+      // 不读取外部的babel.config.js配置文件，全采用babelOpts中的babel配置来构建
+      configFile: false,
     }).code;
   }
 


### PR DESCRIPTION
## bug
目前项目中使用father-build babel模式构建项目时，整体的项目构建会受到项目根目录babel.config.js的影响导致项目构建报错

## 解决方法
babel.transform时增加configFile: false配置，让father-build babel模式构建时，不读取外部的babel.config.js配置文件，全采用babelOpts中的babel配置来构建

## 测试
- 修改前：fatehr-build（2.x）构建外部有babel.config.js的工程构建报错
- 修改后：fork后修改了代码的fatehr-build（jianghe20200825-fix）构建外部有babel.config.js的工程成功（忽略了外部的babel.config.js）