### PR TITLE
fix(babel): handle compile error to avoid watch exit

### DIFF
--- a/packages/preset-built-in/package.json
+++ b/packages/preset-built-in/package.json
@@ -40,9 +40,13 @@
     "gulp-babel": "^8.0.0",
     "gulp-if": "^3.0.0",
     "gulp-less": "^4.0.1",
+    "gulp-plumber": "^1.2.1",
     "gulp-typescript": "^5.0.1",
     "less": "^3.11.1",
     "through2": "^3.0.1",
     "vinyl-fs": "^3.0.3"
+  },
+  "devDependencies": {
+    "@types/gulp-plumber": "^0.0.32"
   }
 }

--- a/packages/preset-built-in/src/commands/build/babel.ts
+++ b/packages/preset-built-in/src/commands/build/babel.ts
@@ -3,6 +3,7 @@ import { IConfig } from 'father-types';
 import { existsSync, statSync } from 'fs';
 import { join } from 'path';
 import vfs from 'vinyl-fs';
+import gulpPlumber from 'gulp-plumber';
 import gulpBabel from 'gulp-babel';
 import gulpIf from 'gulp-if';
 import gulpTs from 'gulp-typescript';
@@ -63,6 +64,7 @@ export default async function(opts: {
           allowEmpty: true,
           base: srcPath,
         })
+        .pipe(watch ? gulpPlumber() : through.obj())
         .pipe(
           gulpIf(f => isTsFile(f.path), gulpTs(tsConfig.compilerOptions || {})),
         )


### PR DESCRIPTION
### 简介

修复 babel 模式且启用 watch 的情况下、TypeScript 类型检查错误会导致 father 的 watch 任务中断退出的问题。参考：https://github.com/gulpjs/gulp/issues/2111

### 遗留问题

watch 启动之后可以良好运行，但如果首次启动的时候就存在 TypeScript 编译错误，则还是需要手动重启；考虑到该场景很少，后续再想办法优化