### PR TITLE
移除babel-plugin-react-require

### DIFF
--- a/packages/father-build/src/getBabelConfig.ts
+++ b/packages/father-build/src/getBabelConfig.ts
@@ -69,7 +69,7 @@ export default function(opts: IGetBabelConfigOpts) {
           }]]
           : []),
         ...(lessInBabelMode ? [transformImportLess2Css] : []),
-        require.resolve('babel-plugin-react-require'),
+        ...(isBrowser ? [require.resolve('babel-plugin-react-require')] : []),
         require.resolve('@babel/plugin-syntax-dynamic-import'),
         require.resolve('@babel/plugin-proposal-export-default-from'),
         require.resolve('@babel/plugin-proposal-export-namespace-from'),

--- a/packages/father-build/src/getBabelConfig.ts
+++ b/packages/father-build/src/getBabelConfig.ts
@@ -69,7 +69,6 @@ export default function(opts: IGetBabelConfigOpts) {
           }]]
           : []),
         ...(lessInBabelMode ? [transformImportLess2Css] : []),
-        ...(isBrowser ? [require.resolve('babel-plugin-react-require')] : []),
         require.resolve('@babel/plugin-syntax-dynamic-import'),
         require.resolve('@babel/plugin-proposal-export-default-from'),
         require.resolve('@babel/plugin-proposal-export-namespace-from'),


### PR DESCRIPTION
如果做其它框架组件，没有react将会报错