### PR TITLE
fix: build error TS2507

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "publish": "npm run build && lerna publish"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.13",
+    "@types/jest": "^26.0.20",
     "lerna": "^3.6.0",
     "lerna-changelog": "^0.8.2",
     "puppeteer": "^1.17.0",


### PR DESCRIPTION
用该配置构建失败
```
export default {
  entry: './src/index.ts',
  esm: 'babel',
  cjs: 'babel',
};
```
提示`node_modules/jest-haste-map/build/index.d.ts(125,32): error TS2507: Type 'typeof EventEmitter' is not a constructor function type.`

![image](https://user-images.githubusercontent.com/7274864/104594219-cfc32080-56ab-11eb-9a00-0b18316338fa.png)

经检查是`@types/jest`版本问题导致ts检查失败