### PR TITLE
feat: support config outputPath

### DIFF
--- a/packages/father-build/src/build.ts
+++ b/packages/father-build/src/build.ts
@@ -112,9 +112,10 @@ export async function build(opts: IOpts, extraOpts: IExtraBuildOpts = {}) {
   for (const bundleOpts of bundleOptsArray) {
     validateBundleOpts(bundleOpts, { cwd, rootPath });
 
+    const { outputPath = 'dist' } = bundleOpts;
     // Clean dist
-    log(chalk.gray(`Clean dist directory`));
-    rimraf.sync(join(cwd, 'dist'));
+    log(chalk.gray(`Clean ${outputPath} directory`));
+    rimraf.sync(join(cwd, `${outputPath}`));
 
     // Build umd
     if (bundleOpts.umd) {

--- a/packages/father-build/src/getRollupConfig.ts
+++ b/packages/father-build/src/getRollupConfig.ts
@@ -39,6 +39,7 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
     esm,
     cjs,
     file,
+    outputPath = 'dist',
     target = 'browser',
     extractCSS = false,
     injectCSS = true,
@@ -218,7 +219,7 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
           input,
           output: {
             format,
-            file: join(cwd, `dist/${(esm && (esm as any).file) || `${name}.esm`}.js`),
+            file: join(cwd, `${outputPath}/${(esm && (esm as any).file) || `${name}.esm`}.js`),
           },
           plugins: [...getPlugins(), ...(esm && (esm as any).minify ? [terser(terserOpts)] : [])],
           external: testExternal.bind(null, external, externalsExclude),
@@ -229,7 +230,7 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
                 input,
                 output: {
                   format,
-                  file: join(cwd, `dist/${(esm && (esm as any).file) || `${name}`}.mjs`),
+                  file: join(cwd, `${outputPath}/${(esm && (esm as any).file) || `${name}`}.mjs`),
                 },
                 plugins: [
                   ...getPlugins(),
@@ -250,7 +251,7 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
           input,
           output: {
             format,
-            file: join(cwd, `dist/${(cjs && (cjs as any).file) || name}.js`),
+            file: join(cwd, `${outputPath}/${(cjs && (cjs as any).file) || name}.js`),
           },
           plugins: [...getPlugins(), ...(cjs && (cjs as any).minify ? [terser(terserOpts)] : [])],
           external: testExternal.bind(null, external, externalsExclude),
@@ -272,7 +273,7 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
           output: {
             format,
             sourcemap: umd && umd.sourcemap,
-            file: join(cwd, `dist/${(umd && umd.file) || `${name}.umd`}.js`),
+            file: join(cwd, `${outputPath}/${(umd && umd.file) || `${name}.umd`}.js`),
             globals: umd && umd.globals,
             name: (umd && umd.name) || (pkg.name && camelCase(basename(pkg.name))),
           },
@@ -293,7 +294,7 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
                 output: {
                   format,
                   sourcemap: umd && umd.sourcemap,
-                  file: join(cwd, `dist/${(umd && umd.file) || `${name}.umd`}.min.js`),
+                  file: join(cwd, `${outputPath}/${(umd && umd.file) || `${name}.umd`}.min.js`),
                   globals: umd && umd.globals,
                   name: (umd && umd.name) || (pkg.name && camelCase(basename(pkg.name))),
                 },

--- a/packages/father-build/src/schema.ts
+++ b/packages/father-build/src/schema.ts
@@ -7,6 +7,7 @@ export default {
     entry: {
       oneOf: [noEmptyStr, { type: 'array', items: noEmptyStr }],
     },
+    outputPath: { type: 'string' },
     file: { type: 'string' },
     esm: {
       oneOf: [

--- a/packages/father-build/src/types.d.ts
+++ b/packages/father-build/src/types.d.ts
@@ -30,6 +30,7 @@ interface IUmd {
 
 export interface IBundleOptions {
   entry?: string | string[];
+  outputPath?: string;
   file?: string;
   esm?: BundleType | IEsm | false;
   cjs?: BundleType | ICjs | false;


### PR DESCRIPTION
给 .fatherrc 新增配置项, outputPath（默认 `'dist'`），可自定义修改

demo

```js
export default {
  outputPath: 'lib', // 新增配置项
  esm: 'rollup',
  cjs: 'rollup',
};
```