### PR TITLE
ci: fix circleci failed

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:latest-browsers
+      - image: circleci/node:14-browsers
     environment:
       CI: true
       NODE_ENV: test

--- a/circle.yml
+++ b/circle.yml
@@ -24,14 +24,14 @@ jobs:
       - checkout
       - restore_cache:
           key: node-modules-{{ checksum "package.json" }}
-      - run: yarn
-      - run: yarn bootstrap --npm-client yarn
-      - run: yarn build
+      - run: npm install
+      - run: npm run bootstrap
+      - run: npm run build
       - run:
-          command: yarn test --forceExit --detectOpenHandles --runInBand --maxWorkers=2
+          command: npm test --forceExit --detectOpenHandles --runInBand --maxWorkers=2
           no_output_timeout: 300m
       - run: bash <(curl -s https://codecov.io/bash)
       - save_cache:
           key: node-modules-{{ checksum "package.json" }}
           paths:
-            - ./node_modules
+            - ~/.cache/npm

--- a/circle.yml
+++ b/circle.yml
@@ -28,7 +28,7 @@ jobs:
       - run: npm run bootstrap
       - run: npm run build
       - run:
-          command: npm test -- --forceExit --detectOpenHandles --maxWorkers=4
+          command: npm test -- --forceExit
           no_output_timeout: 300m
       - run: bash <(curl -s https://codecov.io/bash)
       - save_cache:

--- a/circle.yml
+++ b/circle.yml
@@ -28,7 +28,7 @@ jobs:
       - run: npm run bootstrap
       - run: npm run build
       - run:
-          command: npm test -- --forceExit --detectOpenHandles --runInBand --maxWorkers=2
+          command: npm test -- --forceExit --detectOpenHandles --maxWorkers=4
           no_output_timeout: 300m
       - run: bash <(curl -s https://codecov.io/bash)
       - save_cache:

--- a/circle.yml
+++ b/circle.yml
@@ -28,7 +28,7 @@ jobs:
       - run: npm run bootstrap
       - run: npm run build
       - run:
-          command: npm test -- --forceExit
+          command: npm test
           no_output_timeout: 300m
       - run: bash <(curl -s https://codecov.io/bash)
       - save_cache:

--- a/circle.yml
+++ b/circle.yml
@@ -28,7 +28,7 @@ jobs:
       - run: npm run bootstrap
       - run: npm run build
       - run:
-          command: npm test --forceExit --detectOpenHandles --runInBand --maxWorkers=2
+          command: npm test -- --forceExit --detectOpenHandles --runInBand --maxWorkers=2
           no_output_timeout: 300m
       - run: bash <(curl -s https://codecov.io/bash)
       - save_cache:


### PR DESCRIPTION
CircleCI 从某个时间开始 yarn bootstrap 过程中会莫名 kill，怀疑是 node-sass 安装的问题，但尝试增加执行内存、切换 Node.js 版本号、延长 no_ouput_timeout 等都没有解决问题，且本地和其他 CI 平台无法复现

故切换到 npm 安装 + 使用 Node.js v14 以避开 CircleCI 挂掉的问题，真实原因仍然未知