### PR TITLE
perf: add __tests__ dir in patterns

### DIFF
--- a/packages/father-build/src/babel.ts
+++ b/packages/father-build/src/babel.ts
@@ -188,6 +188,7 @@ export default async function(opts: IBabelOpts) {
       `!${join(srcPath, "**/fixtures{,/**}")}`,
       `!${join(srcPath, "**/demos{,/**}")}`,
       `!${join(srcPath, "**/__test__{,/**}")}`,
+      `!${join(srcPath, "**/__tests__{,/**}")}`,
       `!${join(srcPath, "**/*.mdx")}`,
       `!${join(srcPath, "**/*.md")}`,
       `!${join(srcPath, "**/*.+(test|e2e|spec).+(js|jsx|ts|tsx)")}`


### PR DESCRIPTION
babel 模式下，https://github.com/umijs/father#%E5%85%B3%E4%BA%8E-babel-%E6%A8%A1%E5%BC%8F ，这些目录不会被编译到 es、lib 目录下，
希望添加一下 `__tests__` ，Jest 测试目录，除了使用 `__test__`，一般更习惯用 `__tests__` 。