### PR TITLE
feat: return dispose for cancel build watch

### DIFF
--- a/packages/father-build/src/babel.ts
+++ b/packages/father-build/src/babel.ts
@@ -14,7 +14,7 @@ import gulpPlumber from 'gulp-plumber';
 import gulpIf from "gulp-if";
 import chalk from "chalk";
 import getBabelConfig from "./getBabelConfig";
-import { IBundleOptions } from "./types";
+import { Dispose, IBundleOptions } from "./types";
 import * as ts from "typescript";
 
 interface IBabelOpts {
@@ -24,6 +24,7 @@ interface IBabelOpts {
   target?: "browser" | "node";
   log?: (string) => void;
   watch?: boolean;
+  dispose?: Dispose[];
   importLibToEs?: boolean;
   bundleOpts: IBundleOptions;
 }
@@ -42,6 +43,7 @@ export default async function(opts: IBabelOpts) {
     rootPath,
     type,
     watch,
+    dispose,
     importLibToEs,
     log,
     bundleOpts: {
@@ -228,6 +230,7 @@ export default async function(opts: IBabelOpts) {
         process.once("SIGINT", () => {
           watcher.close();
         });
+        dispose?.push(() => watcher.close());
       }
       resolve();
     });

--- a/packages/father-build/src/rollup.ts
+++ b/packages/father-build/src/rollup.ts
@@ -1,7 +1,7 @@
 import { ModuleFormat, rollup, watch } from 'rollup';
 import signale from 'signale';
 import getRollupConfig from './getRollupConfig';
-import { IBundleOptions } from './types';
+import { Dispose, IBundleOptions } from './types';
 import normalizeBundleOpts from './normalizeBundleOpts';
 
 interface IRollupOpts {
@@ -11,11 +11,12 @@ interface IRollupOpts {
   log: (string) => void;
   bundleOpts: IBundleOptions;
   watch?: boolean;
+  dispose?: Dispose[];
   importLibToEs?: boolean;
 }
 
 async function build(entry: string, opts: IRollupOpts) {
-  const { cwd, type, log, bundleOpts, importLibToEs } = opts;
+  const { cwd, type, log, bundleOpts, importLibToEs, dispose } = opts;
   const rollupConfigs = getRollupConfig({
     cwd,
     type,
@@ -42,6 +43,7 @@ async function build(entry: string, opts: IRollupOpts) {
       process.once('SIGINT', () => {
         watcher.close();
       });
+      dispose?.push(() => watcher.close());
     } else {
       const { output, ...input } = rollupConfig;
       const bundle = await rollup(input); // eslint-disable-line

--- a/packages/father-build/src/types.d.ts
+++ b/packages/father-build/src/types.d.ts
@@ -92,3 +92,5 @@ export interface IOpts {
   rootConfig?: IBundleOptions;
   rootPath?: string;
 }
+
+export type Dispose = () => void;


### PR DESCRIPTION
子进程的测试用例不太好写，可以用这个 file 来验证下

```js
require('father-build')
  .default({
    cwd: process.cwd(),
    watch: true,
    buildArgs: {
      cjs: 'rollup',
      esm: 'babel',
    },
  })
  .then((cancel) => {
    console.log('process should exit after 2000');
    setTimeout(() => {
      cancel();
    }, 2000);
  });

```