### PR TITLE
为 extraRollupPlugins 增加灵活配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,24 @@ export default {
 };
 ```
 
+支持指定位置 
+
+`before` 在指定插件前插入 
+
+`after` 在指定插件后插入
+
+`replace` 替换指定插件
+
+```js
+import vue from 'rollup-plugin-vue'
+import url from 'rollup-plugin-url';
+
+export default {
+    //在babel插件前插入 vue 插件
+    extraRollupPlugins: [{ before: "babel", plugins: [vue()] }]
+}
+```
+
 #### extraExternals
 
 为 rollup 模式配置额外的 external，但不推荐这么做，external 可通过 dependencies 和 peerDependencies 的约定实现。

--- a/packages/father-build/src/getRollupConfig.ts
+++ b/packages/father-build/src/getRollupConfig.ts
@@ -146,7 +146,7 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
 
   function getPlugins(opts = {} as { minCSS: boolean; }) {
     const { minCSS } = opts;
-    return [
+    const plugins = [
       url(),
       svgr(),
       postcss({
@@ -209,8 +209,18 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
         : []),
       babel(babelOpts),
       json(),
-      ...(extraRollupPlugins || []),
     ];
+    (extraRollupPlugins || []).forEach(plugin => {
+        if(plugin.after || plugin.before || plugin.replace){
+            let index = plugins.findIndex(p => p.name === (plugin.after || plugin.before || plugin.replace))
+            if(index > -1) index += plugin.after ? 1 : 0
+            if(index < plugins.length) plugins.splice(index,plugin.replace ? 1 : 0,...plugin.plugins)
+            else plugins.push(...plugin.plugins)
+        }else{
+            plugins.push(plugin)
+        }
+    })
+    return plugins
   }
 
   switch (type) {


### PR DESCRIPTION
https://github.com/umijs/father/pull/279

https://github.com/umijs/father/issues/210

支持指定位置 

`before` 在指定插件前插入 

`after` 在指定插件后插入

`replace` 替换指定插件

```js
import vue from 'rollup-plugin-vue'
import url from 'rollup-plugin-url';

export default {
    //在babel插件前插入 vue 插件
    extraRollupPlugins: [{ before: "babel", plugins: [vue()] }]
}
```