### PR TITLE
fix: 修复pkgs配置只在 father-build 生效

### DIFF
--- a/packages/father-build/src/build.ts
+++ b/packages/father-build/src/build.ts
@@ -184,7 +184,7 @@ export async function build(opts: IOpts, extraOpts: IExtraBuildOpts = {}) {
 }
 
 export async function buildForLerna(opts: IOpts) {
-  const { cwd } = opts;
+  const { cwd, rootConfig = {}, buildArgs = {} } = opts;
 
   // register babel for config files
   registerBabel({
@@ -192,7 +192,7 @@ export async function buildForLerna(opts: IOpts) {
     only: CONFIG_FILES,
   });
 
-  const userConfig = merge(getUserConfig({ cwd }), opts.rootConfig || {});
+  const userConfig = merge(getUserConfig({ cwd }), rootConfig, buildArgs);
 
   let pkgs = await getPackages(cwd);
 


### PR DESCRIPTION
传入的是opts.buildArgs 读取的是opts.rootConfig
![50815B3F-9E1A-4655-86AD-AA8B8F2F3A88](https://user-images.githubusercontent.com/19340899/118611727-bb289d80-b7ef-11eb-9849-b291e709d1c1.png)
