### PR TITLE
fix: babel build remove all tsconfig.json

### DIFF
--- a/packages/father-build/src/babel.ts
+++ b/packages/father-build/src/babel.ts
@@ -193,7 +193,8 @@ export default async function(opts: IBabelOpts) {
       `!${join(srcPath, "**/__tests__{,/**}")}`,
       `!${join(srcPath, "**/*.mdx")}`,
       `!${join(srcPath, "**/*.md")}`,
-      `!${join(srcPath, "**/*.+(test|e2e|spec).+(js|jsx|ts|tsx)")}`
+      `!${join(srcPath, "**/*.+(test|e2e|spec).+(js|jsx|ts|tsx)")}`,
+      `!${join(srcPath, "**/tsconfig{,.*}.json")}`,
     ];
     createStream(patterns).on("end", () => {
       if (watch) {


### PR DESCRIPTION
tsconfig  in src dir will be copied without compiled