### PR TITLE
fix(getBabelConfig): remove babel-plugin-react-require when target is…

### DIFF
--- a/packages/father-build/src/getBabelConfig.ts
+++ b/packages/father-build/src/getBabelConfig.ts
@@ -69,7 +69,7 @@ export default function(opts: IGetBabelConfigOpts) {
           }]]
           : []),
         ...(lessInBabelMode ? [transformImportLess2Css] : []),
-        require.resolve('babel-plugin-react-require'),
+        ...(isBrowser ? [require.resolve('babel-plugin-react-require')] : []),
         require.resolve('@babel/plugin-syntax-dynamic-import'),
         require.resolve('@babel/plugin-proposal-export-default-from'),
         require.resolve('@babel/plugin-proposal-export-namespace-from'),


### PR DESCRIPTION
修复 ：
target 是node 的情况下。 不默认导入 babel-plugin-react-require