### PR TITLE
add @rollup/plugin-commonjs to esm & cjs

### DIFF
--- a/packages/father-build/src/getRollupConfig.ts
+++ b/packages/father-build/src/getRollupConfig.ts
@@ -180,6 +180,10 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
         extensions,
         ...nodeResolveOpts,
       }),
+      commonjs({
+        include,
+        // namedExports options has been remove from https://github.com/rollup/plugins/pull/149
+      }),
       ...(isTypeScript
         ? [
           typescript2({
@@ -265,14 +269,6 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
       ];
 
     case 'umd':
-      // Add umd related plugins
-      const extraUmdPlugins = [
-        commonjs({
-          include,
-          // namedExports options has been remove from https://github.com/rollup/plugins/pull/149
-        }),
-      ];
-
       return [
         {
           input,
@@ -285,7 +281,6 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
           },
           plugins: [
             ...getPlugins(),
-            ...extraUmdPlugins,
             replace({
               'process.env.NODE_ENV': JSON.stringify('development'),
             }),
@@ -306,7 +301,6 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
                 },
                 plugins: [
                   ...getPlugins({ minCSS: true }),
-                  ...extraUmdPlugins,
                   replace({
                     'process.env.NODE_ENV': JSON.stringify('production'),
                   }),


### PR DESCRIPTION
当导出为 esm 或 cjs 时，如果依赖的库里有 commonjs 模块会报错，如很多库都依赖 `@babel/runtime` 而里面很多都是 commonjs 的，报错如下：

```bash
Error: 'default' is not exported by node_modules/@babel/runtime/helpers/defineProperty.js, imported by ...
```