### PR TITLE
fix: rollup watch 模式的构建依赖问题

### DIFF
--- a/packages/father-build/src/rollup.ts
+++ b/packages/father-build/src/rollup.ts
@@ -1,5 +1,6 @@
 import { ModuleFormat, rollup, watch } from 'rollup';
 import signale from 'signale';
+import chalk from 'chalk';
 import getRollupConfig from './getRollupConfig';
 import { Dispose, IBundleOptions } from './types';
 import normalizeBundleOpts from './normalizeBundleOpts';
@@ -35,13 +36,19 @@ async function build(entry: string, opts: IRollupOpts) {
           watch: {},
         },
       ]);
-      watcher.on('event', event => {
-        if (event.error) {
-          signale.error(event.error);
-        } else if (event.code === 'START') {
-          log(`[${type}] Rebuild since file changed`);
-        }
-      });
+      await (new Promise<void>((resolve) => {
+        watcher.on('event', (event) => {
+          // 每次构建完成都会触发 BUNDLE_END 事件
+          // 当第一次构建完成或出错就 resolve
+          if (event.code === 'ERROR') {
+            signale.error(event.error);
+            resolve();
+          } else if (event.code === 'BUNDLE_END') {
+            log(`${chalk.green(`Build ${type} success`)} ${chalk.gray(`entry: ${entry}`)}`);
+            resolve();
+          }
+        });
+      }));
       process.once('SIGINT', () => {
         watcher.close();
       });
@@ -50,6 +57,7 @@ async function build(entry: string, opts: IRollupOpts) {
       const { output, ...input } = rollupConfig;
       const bundle = await rollup(input); // eslint-disable-line
       await bundle.write(output); // eslint-disable-line
+      log(`${chalk.green(`Build ${type} success`)} ${chalk.gray(`entry: ${entry}`)}`);
     }
   }
 }
@@ -62,5 +70,8 @@ export default async function(opts: IRollupOpts) {
     }
   } else {
     await build(opts.entry, opts);
+  }
+  if (opts.watch) {
+    opts.log(chalk.magentaBright(`Rebuild ${opts.type} since file changed 👀`));
   }
 }


### PR DESCRIPTION
如果对构建顺序有要求（指定了 `pkgs`），例如：

```
{
  pkgs: ['pkg-1', 'pkg-2']
}
```

此时，如果使用 `rollup.watch` 模式构建，在 `pkg-1` 尚未完成第一次构建的时候，就会开始 `pkg-2` 的构建。

因为对构建顺序有要求，所以会导致 `pkg-2` 构建失败。

---

同时，这个 PR 优化了控制台的输出。

![image](https://user-images.githubusercontent.com/74411555/140637087-797bb7f6-5065-40f7-a37f-121816ea0bb4.png)

![image](https://user-images.githubusercontent.com/74411555/140637072-322bf67c-7fd1-40bf-92eb-1e5db9e77a35.png)
