### PR TITLE
fix: 修复extraRollupPlugins重复引入相同插件，传入的配置参数无法覆盖原有配置的问题【https://github.c…

### DIFF
--- a/packages/father-build/src/getRollupConfig.ts
+++ b/packages/father-build/src/getRollupConfig.ts
@@ -154,8 +154,8 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
     const pluginsMap = Object.assign(
       Object.fromEntries(defaultRollupPlugins.map(plugin => [plugin.name, plugin])),
       Object.fromEntries(extraRollupPlugins.map(plugin => [plugin.name, plugin]))
-    )
-    return Object.values(pluginsMap)
+    );
+    return Object.values(pluginsMap);
   }
 
   function getPlugins(opts = {} as { minCSS: boolean; }) {

--- a/packages/father-build/src/getRollupConfig.ts
+++ b/packages/father-build/src/getRollupConfig.ts
@@ -222,8 +222,8 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
         ]
         : []),
       babel(babelOpts),
-      json()
-    ]
+      json(),
+    ];
     return mergePlugins(defaultRollupPlugins, extraRollupPlugins || []);
   }
 

--- a/packages/father-build/src/getRollupConfig.ts
+++ b/packages/father-build/src/getRollupConfig.ts
@@ -150,10 +150,12 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
   };
 
   // https://github.com/umijs/father/issues/164
-  function mergePluins(defaultRollupPlugins: Array<RollupPluginOpts> = [], extraRollupPlugins: Array<RollupPluginOpts> = []) {
-    const pluginArray = [...defaultRollupPlugins.map(({ name }) => name), ...extraRollupPlugins.map(({ name }) => name)]
-    const getPluginInArray = (plugins: Array<RollupPluginOpts>, pluginName: string) => plugins.find(({ name }) => name === pluginName)
-    return pluginArray.map(pluginName => getPluginInArray(extraRollupPlugins, pluginName) || getPluginInArray(defaultRollupPlugins, pluginName))
+  function mergePlugins(defaultRollupPlugins: Array<RollupPluginOpts> = [], extraRollupPlugins: Array<RollupPluginOpts> = []) {
+    const pluginsMap = Object.assign(
+      Object.fromEntries(defaultRollupPlugins.map(plugin => [plugin.name, plugin])),
+      Object.fromEntries(extraRollupPlugins.map(plugin => [plugin.name, plugin]))
+    )
+    return Object.values(pluginsMap)
   }
 
   function getPlugins(opts = {} as { minCSS: boolean; }) {
@@ -222,7 +224,7 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
       babel(babelOpts),
       json()
     ]
-    return mergePluins(defaultRollupPlugins, extraRollupPlugins || []);
+    return mergePlugins(defaultRollupPlugins, extraRollupPlugins || []);
   }
 
   switch (type) {

--- a/packages/father-build/src/getRollupConfig.ts
+++ b/packages/father-build/src/getRollupConfig.ts
@@ -151,9 +151,9 @@ export default function(opts: IGetRollupConfigOpts): RollupOptions[] {
 
   // https://github.com/umijs/father/issues/164
   function mergePluins(defaultRollupPlugins: Array<RollupPluginOpts> = [], extraRollupPlugins: Array<RollupPluginOpts> = []) {
-    const defaultRollupPluginNames = defaultRollupPlugins.map(({ name }) => name)
+    const pluginArray = [...defaultRollupPlugins.map(({ name }) => name), ...extraRollupPlugins.map(({ name }) => name)]
     const getPluginInArray = (plugins: Array<RollupPluginOpts>, pluginName: string) => plugins.find(({ name }) => name === pluginName)
-    return defaultRollupPluginNames.map(pluginName => getPluginInArray(extraRollupPlugins, pluginName) || getPluginInArray(defaultRollupPlugins, pluginName))
+    return pluginArray.map(pluginName => getPluginInArray(extraRollupPlugins, pluginName) || getPluginInArray(defaultRollupPlugins, pluginName))
   }
 
   function getPlugins(opts = {} as { minCSS: boolean; }) {


### PR DESCRIPTION
…om/umijs/father/issues/164】