### PR TITLE
fix(umd): webpack persistent cache deps

### DIFF
--- a/src/builder/bundle/index.ts
+++ b/src/builder/bundle/index.ts
@@ -17,6 +17,7 @@ const {
 export default async (opts: {
   cwd: string;
   configProvider: BundleConfigProvider;
+  buildDependencies?: string[];
 }) => {
   const enableCache = process.env.FATHER_CACHE !== 'none';
 
@@ -104,6 +105,7 @@ export default async (opts: {
       ...(enableCache
         ? {
             cache: {
+              buildDependencies: opts.buildDependencies,
               cacheDirectory: path.join(opts.cwd, CACHE_PATH, 'bundle-webpack'),
             },
           }

--- a/src/builder/index.ts
+++ b/src/builder/index.ts
@@ -31,6 +31,7 @@ interface IBuilderOpts {
   pkg: IApi['pkg'];
   clean?: boolean;
   quiet?: boolean;
+  buildDependencies?: string[];
 }
 
 interface IWatchBuilderResult {
@@ -66,6 +67,7 @@ async function builder(
     await bundle({
       cwd: opts.cwd,
       configProvider: configProviders.bundle,
+      buildDependencies: opts.buildDependencies,
     });
   }
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -15,9 +15,10 @@ export default (api: IApi) => {
         pkg: api.pkg,
         clean: args.clean,
         quiet: args.quiet,
-        buildDependencies: [api.service.configManager!.mainConfigFile].filter(
-          Boolean,
-        ) as string[],
+        buildDependencies: [
+          api.pkgPath,
+          api.service.configManager!.mainConfigFile,
+        ].filter(Boolean) as string[],
       });
     },
   });

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -15,6 +15,9 @@ export default (api: IApi) => {
         pkg: api.pkg,
         clean: args.clean,
         quiet: args.quiet,
+        buildDependencies: [api.service.configManager!.mainConfigFile].filter(
+          Boolean,
+        ) as string[],
       });
     },
   });


### PR DESCRIPTION
umd 构建，持久化缓存要和 pkg.json 以及配置文件内容挂钩，否则改了配置文件再次打包仍然是旧的产物。