### PR TITLE
pr(dependency): support less@4.1.3 or later

### DIFF
--- a/packages/father-build/package.json
+++ b/packages/father-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "father-build",
-  "version": "1.22.5",
+  "version": "1.22.6",
   "description": "Library build tool based on rollup.",
   "main": "lib/index.js",
   "bin": {
@@ -43,7 +43,7 @@
     "es5-imcompatible-versions": "^0.1.37",
     "glob": "^7.1.4",
     "gulp-if": "2.0.2",
-    "gulp-less": "^4.0.1",
+    "gulp-less": "^5.0.0",
     "gulp-plumber": "^1.2.1",
     "gulp-typescript": "5.0.1",
     "less": "3.9.0",

--- a/packages/father/package.json
+++ b/packages/father/package.json
@@ -1,6 +1,6 @@
 {
   "name": "father",
-  "version": "2.30.23",
+  "version": "2.30.24",
   "description": "Library toolkit based on rollup, docz, storybook, jest and eslint.",
   "homepage": "http://github.com/umijs/father",
   "bugs": "http://github.com/umijs/father/issues",
@@ -34,7 +34,7 @@
     "docz-core": "1.2.0",
     "docz-plugin-umi-css": "^0.14.1",
     "docz-theme-umi": "^2.0.0",
-    "father-build": "1.22.5",
+    "father-build": "1.22.6",
     "fs-extra": "^8.0.1",
     "gh-pages": "2.0.1",
     "lodash": "^4.17.20",


### PR DESCRIPTION
The ``gulp-less`` has been upgraded to ``^5.0.0`` and now can support less 4.1.3 and later.