### PR TITLE
fix: sourcemap url

### DIFF
--- a/src/builder/utils.ts
+++ b/src/builder/utils.ts
@@ -6,7 +6,7 @@ export function addSourceMappingUrl(code: string, loc: string) {
   return (
     code +
     '\n//# sourceMappingURL=' +
-    path.basename(loc.replace(/\.(jsx|tsx?)$/, '.js'))
+    path.basename(loc.replace(/\.(jsx|tsx?)$/, '.js.map'))
   );
 }
 

--- a/tests/fixtures/build/build-sourcemap/expect.ts
+++ b/tests/fixtures/build/build-sourcemap/expect.ts
@@ -9,6 +9,8 @@ export default (files: Record<string, string>) => {
 
   // esm transform by babel
   expect('esm/index.js.map' in files).toBe(true);
+  expect(files['esm/index.js']).toContain('//# sourceMappingURL=index.js.map');
+
   const map1 = JSON.parse(
     readFileSync(join(__dirname, 'dist/esm/index.js.map'), 'utf-8'),
   );
@@ -21,6 +23,7 @@ export default (files: Record<string, string>) => {
 
   // cjs transform by esbuild
   expect('cjs/index.js.map' in files).toBe(true);
+  expect(files['cjs/index.js']).toContain('//# sourceMappingURL=index.js.map');
   const map3 = JSON.parse(
     readFileSync(join(__dirname, 'dist/cjs/index.js.map'), 'utf-8'),
   );

--- a/tests/fixtures/build/bundless-swc-sourcemap/expect.ts
+++ b/tests/fixtures/build/bundless-swc-sourcemap/expect.ts
@@ -7,8 +7,10 @@ export default (files: Record<string, string>) => {
     '//# sourceMappingURL=index.min.js.map',
   );
 
-  // esm transform by babel
+  // esm transform by swc
   expect('esm/index.js.map' in files).toBe(true);
+  expect(files['esm/index.js']).toContain('//# sourceMappingURL=index.js.map');
+
   const map1 = JSON.parse(
     readFileSync(join(__dirname, 'dist/esm/index.js.map'), 'utf-8'),
   );
@@ -19,8 +21,9 @@ export default (files: Record<string, string>) => {
   );
   expect(map2.sources[0]).toEqual('../../../src/utils/index.ts');
 
-  // cjs transform by esbuild
+  // cjs transform by swc
   expect('cjs/index.js.map' in files).toBe(true);
+  expect(files['cjs/index.js']).toContain('//# sourceMappingURL=index.js.map');
   const map3 = JSON.parse(
     readFileSync(join(__dirname, 'dist/cjs/index.js.map'), 'utf-8'),
   );


### PR DESCRIPTION
修复bundleless模式下使用babel或者swc导致sourceMappingURL后缀错误 #553 