### PR TITLE
refactor: react jsx runtime respect tsconfig.json

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,9 +115,9 @@ importers:
 
   tests/fixtures/build/automatic-jsx:
     specifiers:
-      react: ^17.0.0
+      react: ^16.14.0
     dependencies:
-      react: 17.0.2
+      react: 16.14.0
 
   tests/fixtures/build/classic-jsx:
     specifiers:
@@ -2859,8 +2859,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      JSONStream: 1.3.5
       is-text-path: 1.0.1
+      JSONStream: 1.3.5
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -6461,7 +6461,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-    dev: true
 
   /ps-tree/1.2.0:
     resolution: {integrity: sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==}
@@ -6558,7 +6557,6 @@ packages:
 
   /react-is/16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-    dev: true
 
   /react-is/17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -6576,15 +6574,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.8.1
-    dev: true
-
-  /react/17.0.2:
-    resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-    dev: false
 
   /react/18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}

--- a/src/builder/bundle/index.ts
+++ b/src/builder/bundle/index.ts
@@ -69,7 +69,10 @@ export default async (opts: {
           presetEnv: {
             targets: getBundleTargets(config),
           },
-          presetReact: getBabelPresetReactOpts(opts.configProvider.pkg),
+          presetReact: getBabelPresetReactOpts(
+            opts.configProvider.pkg,
+            opts.cwd,
+          ),
           presetTypeScript: {},
           pluginTransformRuntime: {},
           pluginLockCoreJS: {},

--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -40,7 +40,7 @@ export default async function getDeclarations(
 
   if (tsconfig) {
     // check tsconfig error
-    /* istanbul ignore if -- @preserve */
+    // istanbul-ignore-if
     if (tsconfig.errors.length) {
       throw new Error(
         `Error parsing tsconfig.json content: ${chalk.redBright(
@@ -131,7 +131,7 @@ export default async function getDeclarations(
     });
 
     // check compile error
-    /* istanbul ignore if -- @preserve */
+    // istanbul-ignore-if
     if (result.diagnostics.length) {
       result.diagnostics.forEach((d) => {
         const loc = ts.getLineAndCharacterOfPosition(d.file!, d.start!);

--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -40,7 +40,7 @@ export default async function getDeclarations(
 
   if (tsconfig) {
     // check tsconfig error
-    // istanbul-ignore-if
+    /* istanbul ignore if -- @preserve */
     if (tsconfig.errors.length) {
       throw new Error(
         `Error parsing tsconfig.json content: ${chalk.redBright(
@@ -131,7 +131,7 @@ export default async function getDeclarations(
     });
 
     // check compile error
-    // istanbul-ignore-if
+    /* istanbul ignore if -- @preserve */
     if (result.diagnostics.length) {
       result.diagnostics.forEach((d) => {
         const loc = ts.getLineAndCharacterOfPosition(d.file!, d.start!);

--- a/src/builder/bundless/loaders/javascript/babel.ts
+++ b/src/builder/bundless/loaders/javascript/babel.ts
@@ -39,7 +39,10 @@ const babelTransformer: IJSTransformer = function (content) {
       targets: getBundlessTargets(this.config),
       modules: this.config.format === IFatherBundlessTypes.ESM ? false : 'auto',
     },
-    presetReact: getBabelPresetReactOpts(this.pkg),
+    presetReact: getBabelPresetReactOpts(
+      this.pkg,
+      path.dirname(this.paths.fileAbsPath),
+    ),
     presetTypeScript: {},
   };
 
@@ -68,7 +71,6 @@ const babelTransformer: IJSTransformer = function (content) {
       version: this.pkg.dependencies?.['@babel/runtime'],
     };
   }
-  // TODO: recommend install @babel/runtime in doctor
   const { code, map } = transform(content, {
     filename: this.paths.fileAbsPath,
     cwd: this.paths.cwd,

--- a/src/builder/bundless/loaders/javascript/swc.ts
+++ b/src/builder/bundless/loaders/javascript/swc.ts
@@ -143,7 +143,10 @@ const swcTransformer: IJSTransformer = async function (content) {
         ...(!isTSFile && isJSXFile ? { jsx: true } : {}),
       },
       transform: {
-        react: getSWCTransformReactOpts(this.pkg),
+        react: getSWCTransformReactOpts(
+          this.pkg,
+          path.dirname(this.paths.fileAbsPath),
+        ),
       },
     },
     module: {

--- a/src/builder/utils.ts
+++ b/src/builder/utils.ts
@@ -29,7 +29,7 @@ export function getBaseTransformReactOpts(pkg: IApi['pkg'], cwd: string) {
     let isNewJSX: boolean;
     const tsconfig = getTsconfig(cwd);
 
-    /* istanbul ignore else */
+    /* istanbul ignore else -- @preserve */
     if (tsconfig) {
       // respect tsconfig first, `4` means `react-jsx`
       isNewJSX = tsconfig.options?.jsx === 4;

--- a/src/builder/utils.ts
+++ b/src/builder/utils.ts
@@ -29,7 +29,7 @@ export function getBaseTransformReactOpts(pkg: IApi['pkg'], cwd: string) {
     let isNewJSX: boolean;
     const tsconfig = getTsconfig(cwd);
 
-    // istanbul-ignore-else
+    /* istanbul ignore else */
     if (tsconfig) {
       // respect tsconfig first, `4` means `react-jsx`
       isNewJSX = tsconfig.options?.jsx === 4;

--- a/tests/fixtures/build/automatic-jsx/package.json
+++ b/tests/fixtures/build/automatic-jsx/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "react": "^17.0.0"
+    "react": "^16.14.0"
   }
 }

--- a/tests/fixtures/build/automatic-jsx/tsconfig.json
+++ b/tests/fixtures/build/automatic-jsx/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}


### PR DESCRIPTION
Bundless 的 babel & SWC、Bundle 的 Webpack 都优先使用 tsconfig.json 中的 jsx 配置来决定 React JSX 的转换方式