### PR TITLE
refactor: warn for noEmit when declaration is true

### DIFF
--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -49,6 +49,15 @@ export default async function getDeclarations(
       );
     }
 
+    // warn if noEmit is false
+    if (tsconfig.options.declaration && tsconfig.options.noEmit === false) {
+      logger.warn(
+        'tsconfig.json `noEmit` is false, will not emit declaration files!',
+      );
+
+      return output;
+    }
+
     // enable declarationMap by default in development mode
     if (
       process.env.NODE_ENV === 'development' &&

--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -40,7 +40,7 @@ export default async function getDeclarations(
 
   if (tsconfig) {
     // check tsconfig error
-    // istanbul-ignore-if
+    /* istanbul ignore if -- @preserve */
     if (tsconfig.errors.length) {
       throw new Error(
         `Error parsing tsconfig.json content: ${chalk.redBright(
@@ -50,7 +50,7 @@ export default async function getDeclarations(
     }
 
     // warn if noEmit is false
-    // istanbul-ignore-if
+    /* istanbul ignore if -- @preserve */
     if (tsconfig.options.declaration && tsconfig.options.noEmit === true) {
       logger.warn(
         'tsconfig.json `noEmit` is true, will not emit declaration files!',

--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -50,9 +50,10 @@ export default async function getDeclarations(
     }
 
     // warn if noEmit is false
-    if (tsconfig.options.declaration && tsconfig.options.noEmit === false) {
+    // istanbul-ignore-if
+    if (tsconfig.options.declaration && tsconfig.options.noEmit === true) {
       logger.warn(
-        'tsconfig.json `noEmit` is false, will not emit declaration files!',
+        'tsconfig.json `noEmit` is true, will not emit declaration files!',
       );
 
       return output;


### PR DESCRIPTION
部分项目可能会用 tsc 检查作为 CI 的一部分，可能在配置里手动加上 `noEmit: true`，但这会导致 father 获取不到 ts program 的输出结果，所以加上警告以提示用户