### PR TITLE
fix: handle SIGINT in dev to avoid pnpm exit with error

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -31,6 +31,9 @@ export async function run(_opts?: IOpts) {
 
   if (command === DEV_COMMAND) {
     process.env.NODE_ENV = 'development';
+    // handle ctrl+c and exit with 0, to avoid pnpm exit with error
+    /* istanbul ignore next -- @preserve */
+    process.on('SIGINT', () => process.exit(0));
   } else if (BUILD_COMMANDS.includes(command)) {
     process.env.NODE_ENV = 'production';
   }


### PR DESCRIPTION
在 dev 命令中处理 Ctrl+C，避免用 pnpm 执行时被当做异常终止，抛出错误信息

Closing #573 