### PR TITLE
feat: improve logger for quiet and time prefix

### DIFF
--- a/src/builder/bundle/index.ts
+++ b/src/builder/bundle/index.ts
@@ -1,8 +1,9 @@
-import { chalk, importLazy, logger } from '@umijs/utils';
+import { chalk, importLazy } from '@umijs/utils';
 import path from 'path';
 import { CACHE_PATH } from '../../constants';
 import type { BundleConfigProvider } from '../config';
 import { getBabelPresetReactOpts, getBundleTargets } from '../utils';
+import { logger } from '../../utils';
 
 const bundler: typeof import('@umijs/bundler-webpack') = importLazy(
   path.dirname(require.resolve('@umijs/bundler-webpack/package.json')),

--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -1,8 +1,8 @@
-import { chalk, logger, winPath } from '@umijs/utils';
+import { chalk, winPath } from '@umijs/utils';
 import fs from 'fs';
 import path from 'path';
 import tsPathsTransformer from 'typescript-transform-paths';
-import { getCache } from '../../../utils';
+import { getCache, logger } from '../../../utils';
 
 /**
  * get parsed tsconfig.json for specific path

--- a/src/builder/config.ts
+++ b/src/builder/config.ts
@@ -1,4 +1,4 @@
-import { logger, winPath } from '@umijs/utils';
+import { winPath } from '@umijs/utils';
 import { Minimatch } from 'minimatch';
 import path from 'path';
 import { loadConfig } from 'tsconfig-paths';
@@ -14,6 +14,7 @@ import {
   IFatherJSTransformerTypes,
   IFatherPlatformTypes,
 } from '../types';
+import { logger } from '../utils';
 
 /**
  * declare bundler config

--- a/src/builder/index.ts
+++ b/src/builder/index.ts
@@ -1,9 +1,10 @@
-import { chokidar, logger, rimraf } from '@umijs/utils';
+import { chokidar, rimraf } from '@umijs/utils';
 import path from 'path';
 import { IApi, IFatherConfig } from '../types';
 import bundle from './bundle';
 import bundless from './bundless';
 import { createConfigProviders } from './config';
+import { logger } from '../utils';
 
 function getProviderOutputs(
   providers: ReturnType<typeof createConfigProviders>,
@@ -30,7 +31,6 @@ interface IBuilderOpts {
   cwd: string;
   pkg: IApi['pkg'];
   clean?: boolean;
-  quiet?: boolean;
   buildDependencies?: string[];
 }
 
@@ -57,7 +57,7 @@ async function builder(
 
   if (opts.clean !== false) {
     // clean output directories
-    logger.info('Clean output directories');
+    logger.quietExpect.info('Clean output directories');
     outputs.forEach((output) => {
       rimraf.sync(path.join(opts.cwd, output));
     });
@@ -76,7 +76,6 @@ async function builder(
       cwd: opts.cwd,
       configProvider: configProviders.bundless.esm,
       watch: opts.watch,
-      quiet: opts.quiet,
     });
 
     opts.watch && watchers.push(watcher);
@@ -87,7 +86,6 @@ async function builder(
       cwd: opts.cwd,
       configProvider: configProviders.bundless.cjs,
       watch: opts.watch,
-      quiet: opts.quiet,
     });
 
     opts.watch && watchers.push(watcher);

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,6 +1,7 @@
-import { deepmerge, logger, yParser } from '@umijs/utils';
+import { deepmerge, yParser } from '@umijs/utils';
 import { BUILD_COMMANDS, DEV_COMMAND } from '../constants';
 import { Service } from '../service/service';
+import { logger } from '../utils';
 import {
   checkLocal,
   checkVersion as checkNodeVersion,
@@ -37,6 +38,9 @@ export async function run(_opts?: IOpts) {
   } else if (BUILD_COMMANDS.includes(command)) {
     process.env.NODE_ENV = 'production';
   }
+
+  // set quiet mode for logger
+  if (args.quiet) logger.setQuiet(args.quiet);
 
   try {
     const service = new Service();

--- a/src/cli/node.ts
+++ b/src/cli/node.ts
@@ -1,4 +1,4 @@
-import { logger } from '@umijs/utils';
+import { logger } from '../utils';
 import { join } from 'path';
 import { existsSync } from 'fs';
 import { FRAMEWORK_NAME, MIN_NODE_VERSION } from '../constants';

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -14,7 +14,6 @@ export default (api: IApi) => {
         cwd: api.cwd,
         pkg: api.pkg,
         clean: args.clean,
-        quiet: args.quiet,
         buildDependencies: [
           api.pkgPath,
           api.service.configManager!.mainConfigFile,

--- a/src/commands/changelog.ts
+++ b/src/commands/changelog.ts
@@ -1,4 +1,4 @@
-import { logger } from '@umijs/utils';
+import { logger } from '../utils';
 import { IApi } from '../types';
 
 export default (api: IApi) => {

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -1,7 +1,7 @@
-import { logger } from '@umijs/utils';
 import builder from '../builder';
 import { DEV_COMMAND } from '../constants';
 import type { IApi } from '../types';
+import { logger } from '../utils';
 
 export default (api: IApi) => {
   api.registerCommand({
@@ -13,7 +13,6 @@ export default (api: IApi) => {
         cwd: api.cwd,
         pkg: api.pkg,
         watch: true,
-        quiet: args.quiet,
       });
 
       // handle config change

--- a/src/commands/generators/commitlint.ts
+++ b/src/commands/generators/commitlint.ts
@@ -1,11 +1,12 @@
 import { GeneratorType } from '@umijs/core';
-import { getNpmClient, logger } from '@umijs/utils';
+import { getNpmClient } from '@umijs/utils';
 import { execSync } from 'child_process';
 import fg from 'fast-glob';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { IApi } from '../../types';
 import { GeneratorHelper } from './utils';
+import { logger } from '../../utils';
 
 export default (api: IApi) => {
   api.describe({
@@ -54,14 +55,14 @@ export default (api: IApi) => {
         extends: ['@commitlint/config-conventional'],
       };
       writeFileSync(api.pkgPath, JSON.stringify(api.pkg, null, 2));
-      logger.info('Update package.json for commitlint');
+      logger.quietExpect.info('Update package.json for commitlint');
 
       h.installDeps();
       const npmClient = getNpmClient({ cwd: api.cwd });
       execSync(
         `${npmClient} husky add .husky/commit-msg '${npmClient} commitlint --edit $1'`,
       );
-      logger.info('Create a hook for commitlint');
+      logger.quietExpect.info('Create a hook for commitlint');
     },
   });
 };

--- a/src/commands/generators/eslint.ts
+++ b/src/commands/generators/eslint.ts
@@ -1,5 +1,5 @@
 import { GeneratorType } from '@umijs/core';
-import { logger } from '@umijs/utils';
+import { logger } from '../../utils';
 import fg from 'fast-glob';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
@@ -45,7 +45,7 @@ module.exports = {
 `.trimStart(),
       );
 
-      logger.info('Write .eslintrc.js');
+      logger.quietExpect.info('Write .eslintrc.js');
 
       h.installDeps();
     },

--- a/src/commands/generators/jest.ts
+++ b/src/commands/generators/jest.ts
@@ -1,5 +1,5 @@
 import { GeneratorType } from '@umijs/core';
-import { logger } from '@umijs/utils';
+import { logger } from '../../utils';
 import { existsSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { IApi } from '../../types';
@@ -60,7 +60,7 @@ export default (api: IApi) => {
           `import '@testing-library/jest-dom';
           `.trimStart(),
         );
-        logger.info('Write jest-setup.ts');
+        logger.quietExpect.info('Write jest-setup.ts');
       }
 
       const collectCoverageFrom = ['src/**/*.{ts,js,tsx,jsx}'];
@@ -92,7 +92,7 @@ export default {
 `.trimStart(),
       );
 
-      logger.info('Write jest.config.ts');
+      logger.quietExpect.info('Write jest.config.ts');
 
       h.installDeps();
     },

--- a/src/commands/generators/lint.ts
+++ b/src/commands/generators/lint.ts
@@ -1,7 +1,8 @@
 import { GeneratorType } from '@umijs/core';
-import { getNpmClient, logger } from '@umijs/utils';
+import { getNpmClient } from '@umijs/utils';
 import { IApi } from '../../types';
 import { GeneratorHelper } from './utils';
+import { logger } from '../../utils';
 
 export default (api: IApi) => {
   api.describe({
@@ -26,7 +27,7 @@ export default (api: IApi) => {
           await generator.fn();
         } else {
           allEnable = false;
-          logger.warn(generator.disabledDescription);
+          logger.quietExpect.warn(generator.disabledDescription);
         }
       }
 

--- a/src/commands/generators/stylelint.ts
+++ b/src/commands/generators/stylelint.ts
@@ -1,9 +1,9 @@
 import { GeneratorType } from '@umijs/core';
-import { logger } from '@umijs/utils';
 import { existsSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { IApi } from '../../types';
 import { GeneratorHelper } from './utils';
+import { logger } from '../../utils';
 
 export default (api: IApi) => {
   api.describe({
@@ -43,7 +43,7 @@ export default (api: IApi) => {
 `.trimStart(),
       );
 
-      logger.info('Write .stylelintrc');
+      logger.quietExpect.info('Write .stylelintrc');
 
       h.installDeps();
     },

--- a/src/commands/generators/utils.ts
+++ b/src/commands/generators/utils.ts
@@ -1,11 +1,7 @@
-import {
-  getNpmClient,
-  installWithNpmClient,
-  logger,
-  prompts,
-} from '@umijs/utils';
+import { getNpmClient, installWithNpmClient, prompts } from '@umijs/utils';
 import { writeFileSync } from 'fs';
 import { IApi } from '../../types';
+import { logger } from '../../utils';
 
 export class GeneratorHelper {
   constructor(readonly api: IApi) {}
@@ -17,14 +13,14 @@ export class GeneratorHelper {
       ...deps,
     };
     writeFileSync(api.pkgPath, JSON.stringify(api.pkg, null, 2));
-    logger.info('Write package.json');
+    logger.quietExpect.info('Write package.json');
   }
 
   addScript(name: string, cmd: string) {
     const { api } = this;
     this.addScriptToPkg(name, cmd);
     writeFileSync(api.pkgPath, JSON.stringify(api.pkg, null, 2));
-    logger.info('Update package.json for scripts');
+    logger.quietExpect.info('Update package.json for scripts');
   }
 
   private addScriptToPkg(name: string, cmd: string) {
@@ -48,7 +44,7 @@ export class GeneratorHelper {
     installWithNpmClient({
       npmClient,
     });
-    logger.info(`Install dependencies with ${npmClient}`);
+    logger.quietExpect.info(`Install dependencies with ${npmClient}`);
   }
 }
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,5 +1,6 @@
-import { chalk, lodash, logger } from '@umijs/utils';
+import { chalk, lodash } from '@umijs/utils';
 import { IApi } from '../types';
+import { logger } from '../utils';
 
 export default (api: IApi) => {
   api.registerCommand({

--- a/src/commands/release.ts
+++ b/src/commands/release.ts
@@ -1,4 +1,4 @@
-import { logger } from '@umijs/utils';
+import { logger } from '../utils';
 import { IApi } from '../types';
 
 export default (api: IApi) => {

--- a/src/features/depsOnDemand/swc.ts
+++ b/src/features/depsOnDemand/swc.ts
@@ -2,6 +2,7 @@ import { resolve } from '@umijs/utils';
 import { join } from 'path';
 import { GeneratorHelper } from '../../commands/generators/utils';
 import { IApi, IFatherJSTransformerTypes } from '../../types';
+import { logger } from '../../utils';
 
 export default (api: IApi) => {
   api.onStart(() => {
@@ -16,7 +17,7 @@ export default (api: IApi) => {
     } catch {}
 
     if (hasSwcConfig && !swcInstalled) {
-      api.logger.info('Since swc is used, install @swc/core on demand.');
+      logger.info('Since swc is used, install @swc/core on demand.');
 
       const h = new GeneratorHelper(api);
       h.addDevDeps({

--- a/src/prebundler/index.ts
+++ b/src/prebundler/index.ts
@@ -1,11 +1,12 @@
 import { Extractor } from '@microsoft/api-extractor';
-import { chalk, logger, winPath } from '@umijs/utils';
+import { chalk, winPath } from '@umijs/utils';
 // @ts-ignore
 import ncc from '@vercel/ncc';
 import fs from 'fs';
 import path from 'path';
 import { getConfig } from './config';
 import { getSharedData } from './shared';
+import { logger } from '../utils';
 
 export default async (opts: Parameters<typeof getConfig>[0]) => {
   // patch @microsoft/api-extractor before prepare config
@@ -74,7 +75,7 @@ export default async (opts: Parameters<typeof getConfig>[0]) => {
 
   // bundle dts
   if (Object.keys(config.dts).length) {
-    logger.event(`Generate declaration files...`);
+    logger.quietExpect.event(`Generate declaration files...`);
 
     for (const dts in config.dts) {
       Extractor.invoke(config.dts[dts].maeConfig, {
@@ -109,7 +110,7 @@ export default async (opts: Parameters<typeof getConfig>[0]) => {
   }
 
   if (count) {
-    logger.event(
+    logger.quietExpect.event(
       `Pre-bundled successfully in ${
         Date.now() - startTime
       } ms (${count} deps)`,

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,58 @@
+import { logger } from '../src/utils';
+import { logger as umiLogger } from '@umijs/utils';
+
+jest.mock('@umijs/utils', () => {
+  const originalModule = jest.requireActual('@umijs/utils');
+
+  return {
+    ...originalModule,
+    logger: {
+      ...originalModule.logger,
+      info: jest.fn(),
+    },
+  };
+});
+
+afterAll(() => {
+  jest.unmock('@umijs/utils');
+});
+
+describe('logger', () => {
+  test('normal', () => {
+    logger.info('normal');
+    expect(umiLogger.info).toBeCalledWith('normal');
+  });
+
+  test('quiet only', () => {
+    logger.setQuiet(false);
+    logger.quietOnly.info('quiet only');
+    expect(umiLogger.info).not.toBeCalledWith('quiet only');
+
+    logger.setQuiet(true);
+    logger.quietOnly.info('quiet only');
+    expect(umiLogger.info).toBeCalledWith('quiet only');
+  });
+
+  test('quiet expect', () => {
+    logger.setQuiet(false);
+    logger.quietExpect.info('quiet expect');
+    expect(umiLogger.info).toBeCalledWith('quiet expect');
+
+    logger.setQuiet(true);
+    logger.quietExpect.info('quiet expect');
+    expect(umiLogger.info).toBeCalledWith('quiet expect');
+  });
+
+  test('prefix time', () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+
+    logger.info('prefix time');
+    expect(umiLogger.info).toBeCalledWith(
+      expect.stringMatching(/(\d{2}:){2}\d{2}/),
+      'prefix time',
+    );
+
+    process.env.NODE_ENV = originalEnv;
+  });
+});


### PR DESCRIPTION
基于 Umi logger 封装 father 的 logger，支持 4 个特性：

1. `logger.quietOnly.xx`，该日志仅在 quiet 模式下输出
2. `logger.quietExpect.xx`，该日志仅在非 quiet 模式下输出
3. `logger.setQuiet`，修改 quiet 状态
4. 在 NODE_ENV 为 development 时，自动给每条日志前面加上时间戳

所有用到 logger 的地方都根据实际需要做了调用调整，包一层 logger 的作用：
1. 能让 quiet 模式的输出更精简
2. 能对全部命令生效，并且最小改动
3. 时间戳方便 watch 时确认最近编译时间

效果：
<img src="https://user-images.githubusercontent.com/5035925/218039633-2fc76ade-c8dc-4045-8df3-42467b25fe13.png" width="500" />

