### PR TITLE
fix: d.ts paths transform bug if project use ts 4.9.x

### DIFF
--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -137,7 +137,14 @@ export default async function getDeclarations(
     // ref: https://www.npmjs.com/package/typescript-transform-paths
     const result = program.emit(undefined, undefined, undefined, true, {
       afterDeclarations: [
-        tsPathsTransformer(program, { afterDeclarations: true }),
+        tsPathsTransformer(
+          program,
+          { afterDeclarations: true },
+          // specific typescript instance, because this plugin is incompatible with typescript@4.9.x currently
+          // but some project may declare typescript and some dependency manager will hoist project's typescript
+          // rather than father's typescript for this plugin
+          { ts },
+        ),
       ],
     });
 


### PR DESCRIPTION
修复当项目依赖了 TypeScript 4.9.x 时，类型产物中的 `paths` 别名没有转换的问题

原因：[typescript-transform-paths](https://www.npmjs.com/package/typescript-transform-paths) 目前不支持 TypeScript 4.9，但也不会报错
解法：father 将自己依赖的 TypeScript 4.8.x 传给插件使用，确保插件拿到的 TypeScript 实例与 father 声明的一致