### PR TITLE
fix: wrong cache when tsconfig declaration changed

### DIFF
--- a/src/builder/bundless/loaders/index.ts
+++ b/src/builder/bundless/loaders/index.ts
@@ -66,8 +66,8 @@ export default async (
   if (cacheRet)
     return Promise.resolve<ILoaderOutput>({
       ...cacheRet,
-      outputOpts: {
-        ...cacheRet.outputOpts,
+      options: {
+        ...cacheRet.options,
         // FIXME: shit code for avoid invalid declaration value when tsconfig changed
         declaration: /\.tsx?$/.test(fileAbsPath)
           ? getTsconfig(opts.cwd)?.options.declaration


### PR DESCRIPTION
修复 tsconfig.json 里 `declaration` 配置项修改时构建缓存复用错误的问题