### PR TITLE
feat: handle svg as normal image assets in bundle mode

### DIFF
--- a/src/builder/bundle/index.ts
+++ b/src/builder/bundle/index.ts
@@ -123,6 +123,13 @@ async function bundless(opts: IBundlessOpts): Promise<void | IBundleWatcher> {
           });
         }
 
+        // also bundle svg as asset, because father force disable svgr
+        const imgRule = memo.module.rule('asset').oneOf('image');
+
+        imgRule.test(
+          new RegExp(imgRule.get('test').source.replace(/(\|png)/, '$1|svg')),
+        );
+
         // disable progress bar
         memo.plugins.delete('progress-plugin');
 


### PR DESCRIPTION
father 禁用 svgr，所以在 bundle 模式下也将 svg 也当做普通图片资源处理，base64 or 转为独立文件