### PR TITLE
feat: add PREFER_PEER_DEPS doctor rule

### DIFF
--- a/src/doctor/rules/PREFER_PEER_DEPS.ts
+++ b/src/doctor/rules/PREFER_PEER_DEPS.ts
@@ -1,0 +1,27 @@
+import type { IDoctorReport } from '..';
+import type { IApi } from '../../types';
+
+const PREFER_PEER_DEPS = ['react', 'react-dom', 'antd'];
+
+export default (api: IApi) => {
+  api.addRegularCheckup(() => {
+    const warns: IDoctorReport = [];
+
+    if (api.pkg.dependencies) {
+      Object.keys(api.pkg.dependencies).forEach((pkg) => {
+        if (
+          PREFER_PEER_DEPS.includes(pkg) &&
+          !api.pkg.peerDependencies?.[pkg]
+        ) {
+          warns.push({
+            type: 'warn',
+            problem: `The dependency \`${pkg}\` has multi-instance risk in host project`,
+            solution: 'Move it into `peerDependencies` from `dependencies`',
+          });
+        }
+      });
+    }
+
+    return warns;
+  });
+};

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -42,6 +42,11 @@ test('doctor: warn checkups', async () => {
   expect(console.log).toHaveBeenCalledWith(
     expect.stringContaining('CSS Modules'),
   );
+
+  // PREFER_PEER_DEPS
+  expect(console.log).toHaveBeenCalledWith(
+    expect.stringContaining('multi-instance risk'),
+  );
 });
 
 test('doctor: error checkups', async () => {

--- a/tests/fixtures/doctor/warns/package.json
+++ b/tests/fixtures/doctor/warns/package.json
@@ -3,7 +3,8 @@
     "*.css"
   ],
   "dependencies": {
-    "hello": "0.0.0"
+    "hello": "0.0.0",
+    "react": "16.9.0"
   },
   "peerDependencies": {
     "hello": "0.0.0"


### PR DESCRIPTION
新增 `PREFER_PEER_DEPS` doctor 规则，用于警告放入 `dependencies` 时有多实例风险的依赖，比如 `react`、`antd`