### PR TITLE
fix: bundless ignore files are still checked in doctor

### DIFF
--- a/tests/fixtures/doctor/errors/.fatherrc.ts
+++ b/tests/fixtures/doctor/errors/.fatherrc.ts
@@ -10,5 +10,6 @@ export default {
       alias: 'alias',
       '@org/alias': '@org/alias',
     },
+    ignores: ['./src/ignore.ts'],
   },
 };

--- a/tests/fixtures/doctor/errors/src/ignore.ts
+++ b/tests/fixtures/doctor/errors/src/ignore.ts
@@ -1,0 +1,5 @@
+// this file should be ignored in doctor
+// @ts-ignore
+import a from 'phantom-dependency';
+
+console.log(a);


### PR DESCRIPTION
修复 bundless `ignores` 配置中的文件仍然会被 doctor 检查的 bug