### PR TITLE
feat: add CJS_IMPORT_ESM doctor rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: [14.x, 16.x, 18.x]
-        os: [ubuntu-latest, windows-latest]
+        node_version: [14.x]
+        os: [windows-latest]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: [14.x]
-        os: [windows-latest]
+        node_version: [14.x, 16.x, 18.x]
+        os: [ubuntu-latest, windows-latest]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -149,6 +149,7 @@ export default async (api: IApi): Promise<IDoctorReport> => {
           imports: (await sourceParser(path.join(api.cwd, file))).imports,
           mergedAlias,
           mergedExternals,
+          configProviders,
         },
       })),
     );

--- a/src/doctor/rules/CJS_IMPORT_ESM.ts
+++ b/src/doctor/rules/CJS_IMPORT_ESM.ts
@@ -1,0 +1,63 @@
+import type { IApi } from '../../types';
+import vm from 'vm';
+import { chalk } from '@umijs/utils';
+import type { IDoctorReport } from '..';
+import { getPkgNameFromPath } from '../utils';
+import enhancedResolve from 'enhanced-resolve';
+
+export default (api: IApi) => {
+  const sandbox = vm.createContext({ require });
+  let resolver: ReturnType<typeof enhancedResolve['create']['sync']>;
+
+  api.addImportsCheckup(
+    ({ file, imports, configProviders, mergedExternals, mergedAlias }) => {
+      const errors: IDoctorReport = [];
+
+      // apply this rule only when cjs available
+      if (api.config.cjs) {
+        // skip if file is ignored by cjs bundless
+        if (configProviders.bundless.cjs!.getConfigForFile(file)) {
+          imports.forEach((i) => {
+            const pkgName = getPkgNameFromPath(i.path);
+
+            // ignore relative import and externalized dep
+            if (
+              pkgName &&
+              !mergedExternals[i.path] &&
+              i.kind === 'import-statement'
+            ) {
+              resolver ??= enhancedResolve.create.sync({
+                alias: mergedAlias,
+              });
+
+              try {
+                const res = resolver(i.resolveDir, i.path);
+
+                // only check npm package
+                // why check node_modules?
+                // because some alias may point to src but also like package name
+                if (res && res.includes('node_modules')) {
+                  vm.runInContext(`require('${res}')`, sandbox);
+                }
+              } catch (e: any) {
+                if (e.code === 'ERR_REQUIRE_ESM') {
+                  errors.push({
+                    type: 'error',
+                    problem: `CommonJS dist file import an ES Module \`${
+                      i.path
+                    }\`, it will cause \`ERR_REQUIRE_ESM\` error in Node.js runtime
+                  ${chalk.gray(`at ${file}`)}`,
+                    solution:
+                      'Convert `import` to `await import`, or find a CommonJS version of the package',
+                  });
+                }
+              }
+            }
+          });
+        }
+      }
+
+      return errors;
+    },
+  );
+};

--- a/src/doctor/rules/CJS_IMPORT_ESM.ts
+++ b/src/doctor/rules/CJS_IMPORT_ESM.ts
@@ -40,7 +40,6 @@ export default (api: IApi) => {
                   vm.runInContext(`require('${winPath(res)}')`, sandbox);
                 }
               } catch (e: any) {
-                console.log(e);
                 if (e.code === 'ERR_REQUIRE_ESM') {
                   errors.push({
                     type: 'error',

--- a/src/doctor/rules/CJS_IMPORT_ESM.ts
+++ b/src/doctor/rules/CJS_IMPORT_ESM.ts
@@ -40,6 +40,7 @@ export default (api: IApi) => {
                   vm.runInContext(`require('${res}')`, sandbox);
                 }
               } catch (e: any) {
+                console.log(e);
                 if (e.code === 'ERR_REQUIRE_ESM') {
                   errors.push({
                     type: 'error',

--- a/src/doctor/rules/CJS_IMPORT_ESM.ts
+++ b/src/doctor/rules/CJS_IMPORT_ESM.ts
@@ -1,6 +1,6 @@
 import type { IApi } from '../../types';
 import vm from 'vm';
-import { chalk } from '@umijs/utils';
+import { chalk, winPath } from '@umijs/utils';
 import type { IDoctorReport } from '..';
 import { getPkgNameFromPath } from '../utils';
 import enhancedResolve from 'enhanced-resolve';
@@ -37,7 +37,7 @@ export default (api: IApi) => {
                 // why check node_modules?
                 // because some alias may point to src but also like package name
                 if (res && res.includes('node_modules')) {
-                  vm.runInContext(`require('${res}')`, sandbox);
+                  vm.runInContext(`require('${winPath(res)}')`, sandbox);
                 }
               } catch (e: any) {
                 console.log(e);

--- a/src/doctor/rules/PHANTOM_DEPS.ts
+++ b/src/doctor/rules/PHANTOM_DEPS.ts
@@ -1,15 +1,14 @@
 import { chalk } from '@umijs/utils';
 import type { IDoctorReport } from '..';
 import type { IApi } from '../../types';
+import { getPkgNameFromPath } from '../utils';
 
 export default (api: IApi) => {
   api.addImportsCheckup(({ file, imports, mergedAlias, mergedExternals }) => {
     const errors: IDoctorReport = [];
 
     imports.forEach((i) => {
-      const pkgName = i.path.match(
-        /^(?:@[a-z\d][\w-.]*\/)?[a-z\d][\w-.]*/i,
-      )?.[0];
+      const pkgName = getPkgNameFromPath(i.path);
       const aliasKeys = Object.keys(mergedAlias);
 
       if (

--- a/src/doctor/utils.ts
+++ b/src/doctor/utils.ts
@@ -1,0 +1,3 @@
+export function getPkgNameFromPath(p: string) {
+  return p.match(/^(?:@[a-z\d][\w-.]*\/)?[a-z\d][\w-.]*/i)?.[0];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,11 @@ import type IWebpackChain from '@umijs/bundler-webpack/compiled/webpack-5-chain'
 import type { IConfig as IBundlerWebpackConfig } from '@umijs/bundler-webpack/dist/types';
 import type { IAdd, IModify, IServicePluginAPI, PluginAPI } from '@umijs/core';
 import type { ITransformerItem } from './builder/bundless/loaders/javascript';
-import type { IBundleConfig, IBundlessConfig } from './builder/config';
+import type {
+  IBundleConfig,
+  IBundlessConfig,
+  createConfigProviders,
+} from './builder/config';
 import type { IDoctorReport } from './doctor';
 import type { IDoctorSourceParseResult } from './doctor/parser';
 import type { IPreBundleConfig } from './prebundler/config';
@@ -48,6 +52,7 @@ export type IApi = PluginAPI &
         imports: IDoctorSourceParseResult['imports'];
         mergedAlias: Record<string, string[]>;
         mergedExternals: Record<string, string>;
+        configProviders: ReturnType<typeof createConfigProviders>;
       },
       IDoctorReport | IDoctorReport[0] | void
     >;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -33,6 +33,7 @@ afterAll(() => {
   delete process.env.APP_ROOT;
   delete process.env.FATHER_CACHE;
   mockExit.mockRestore();
+  jest.unmock('@umijs/utils');
 });
 test('config: cyclic extends', async () => {
   // execute build

--- a/tests/deps.test.ts
+++ b/tests/deps.test.ts
@@ -35,6 +35,7 @@ beforeAll(() => {
 afterAll(() => {
   delete process.env.APP_ROOT;
   delete process.env.FATHER_CACHE;
+  jest.unmock('@umijs/utils');
 });
 
 const CASES_DIR = path.join(__dirname, 'fixtures/deps');

--- a/tests/dev.test.ts
+++ b/tests/dev.test.ts
@@ -112,6 +112,7 @@ afterAll(async () => {
 
   jest.unmock('@umijs/utils');
   jest.unmock('./fixtures/dev/.fatherrc.ts');
+  jest.unmock('../src/builder/bundle/index.ts');
 });
 
 test('dev: file output', () => {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -6,21 +6,10 @@ const CASES_DIR = path.join(__dirname, 'fixtures/doctor');
 const mockExit = mockProcessExit();
 const logSpy = jest.spyOn(console, 'log');
 
-/**
- * jest will intercept ERR_REQUIRE_ESM to show transformer hint
- * so we need to mock esm module to throw real error
- */
-jest.mock('./fixtures/doctor/errors/node_modules/esm/index.js', () => {
-  throw new (class extends Error {
-    code = 'ERR_REQUIRE_ESM';
-  })();
-});
-
 afterAll(() => {
   logSpy.mockRestore();
   mockExit.mockRestore();
   delete process.env.APP_ROOT;
-  jest.unmock('./fixtures/doctor/errors/node_modules/esm/index.js');
 });
 
 test('doctor: warn checkups', async () => {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -6,10 +6,21 @@ const CASES_DIR = path.join(__dirname, 'fixtures/doctor');
 const mockExit = mockProcessExit();
 const logSpy = jest.spyOn(console, 'log');
 
+/**
+ * jest will intercept ERR_REQUIRE_ESM to show transformer hint
+ * so we need to mock esm module to throw real error
+ */
+jest.mock('./fixtures/doctor/errors/node_modules/esm/index.js', () => {
+  throw new (class extends Error {
+    code = 'ERR_REQUIRE_ESM';
+  })();
+});
+
 afterAll(() => {
   logSpy.mockRestore();
   mockExit.mockRestore();
   delete process.env.APP_ROOT;
+  jest.unmock('./fixtures/doctor/errors/node_modules/esm/index.js');
 });
 
 test('doctor: warn checkups', async () => {

--- a/tests/fixtures/doctor/errors/node_modules/esm/index.js
+++ b/tests/fixtures/doctor/errors/node_modules/esm/index.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/tests/fixtures/doctor/errors/node_modules/esm/index.js
+++ b/tests/fixtures/doctor/errors/node_modules/esm/index.js
@@ -1,1 +1,5 @@
-export default 1;
+// why not write real esm code?
+// because jest jest will intercept ERR_REQUIRE_ESM to show transformer hint
+throw new (class extends Error {
+  code = 'ERR_REQUIRE_ESM';
+})

--- a/tests/fixtures/doctor/errors/node_modules/esm/index.js
+++ b/tests/fixtures/doctor/errors/node_modules/esm/index.js
@@ -1,5 +1,1 @@
-// why not write real esm code?
-// because jest jest will intercept ERR_REQUIRE_ESM to show transformer hint
-throw new (class extends Error {
-  code = 'ERR_REQUIRE_ESM';
-})
+export default 1;

--- a/tests/fixtures/doctor/errors/node_modules/esm/package.json
+++ b/tests/fixtures/doctor/errors/node_modules/esm/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "esm",
+  "type": "module",
+  "module": "index.js"
+}

--- a/tests/fixtures/doctor/errors/package.json
+++ b/tests/fixtures/doctor/errors/package.json
@@ -1,4 +1,7 @@
 {
   "sideEffects": false,
-  "files": []
+  "files": [],
+  "dependencies": {
+    "esm": "0.0.0"
+  }
 }

--- a/tests/fixtures/doctor/errors/src/index.ts
+++ b/tests/fixtures/doctor/errors/src/index.ts
@@ -6,6 +6,7 @@ import path from 'child_process';
 import externals from 'externals';
 import hello from 'hello';
 import BigCamelCase from './CamelCase';
+import esm from 'esm';
 import './index.less';
 
 // to avoid esbuild tree-shaking
@@ -17,4 +18,5 @@ console.log(
   orgExternals,
   path,
   BigCamelCase,
+  esm,
 );


### PR DESCRIPTION
新增 `CJS_IMPORT_ESM` doctor 规则，用于检测 cjs 产物里引入的 pure esm 依赖，这会导致 NPM 包发布后在 Node.js 运行时报错，类似：

```bash
Uncaught:
Error [ERR_REQUIRE_ESM]: require() of ES Module /path/to/esm.js not supported.
Instead change the require of index.js in null to a dynamic import() which is available in all CommonJS modules.
```