### PR TITLE
ci: improve sucess rate for windows ci

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,6 +4,7 @@ const defaultConfig = createConfig();
 
 export default {
   ...defaultConfig,
+  testTimeout: 600000,
   moduleNameMapper: {
     ...defaultConfig.moduleNameMapper,
     // @umijs/bundler-webpack requireHook not working for jest

--- a/tests/dev.test.ts
+++ b/tests/dev.test.ts
@@ -208,8 +208,8 @@ test('dev: config change', async () => {
     'utf-8',
   );
 
-  // wait for restart
-  await wait(10000);
+  // wait for restart (at least 5s+ is required to restart in Windows CI)
+  await wait(6000);
 
   const fileMap = distToMap(CASE_DIST);
 

--- a/tests/dev.test.ts
+++ b/tests/dev.test.ts
@@ -209,7 +209,7 @@ test('dev: config change', async () => {
   );
 
   // wait for restart
-  await wait(5000);
+  await wait(10000);
 
   const fileMap = distToMap(CASE_DIST);
 


### PR DESCRIPTION
提升 Windows CI 的测试成功率，之前经常失败但重试又能成功的原因是，在配置文件修改后自动重新构建的 case 里，只等待了 5s，但验证下来 Windows CI 的平均重启构建的时间就是 5s 左右，所以只要执行时间稍长就会失败

解法：把等待时间提升到 6s