### PR TITLE
fix: dts lost when esm and cjs has different ignores

### DIFF
--- a/tests/fixtures/build/bundless-diff-dts/.fatherrc.ts
+++ b/tests/fixtures/build/bundless-diff-dts/.fatherrc.ts
@@ -1,0 +1,6 @@
+export default {
+  cjs: {},
+  esm: {
+    ignores: ['src/ignore.ts'],
+  },
+};

--- a/tests/fixtures/build/bundless-diff-dts/expect.ts
+++ b/tests/fixtures/build/bundless-diff-dts/expect.ts
@@ -1,0 +1,3 @@
+export default (files: Record<string, string>) => {
+  expect(files['cjs/ignore.d.ts']).not.toBeUndefined();
+};

--- a/tests/fixtures/build/bundless-diff-dts/src/ignore.ts
+++ b/tests/fixtures/build/bundless-diff-dts/src/ignore.ts
@@ -1,0 +1,1 @@
+export default 1;

--- a/tests/fixtures/build/bundless-diff-dts/src/index.ts
+++ b/tests/fixtures/build/bundless-diff-dts/src/index.ts
@@ -1,0 +1,5 @@
+export default async () => {
+  try {
+    await import('./ignore');
+  } catch {}
+};

--- a/tests/fixtures/build/bundless-diff-dts/tsconfig.json
+++ b/tests/fixtures/build/bundless-diff-dts/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "declaration": true
+  }
+}


### PR DESCRIPTION
修复 esm 和 cjs 有不同的 `ignores` 配置时，cjs 产物中部分 `.d.ts` 会丢失的问题