### PR TITLE
fix: should not read babel config file

### DIFF
--- a/src/builder/bundless/loaders/javascript/babel.ts
+++ b/src/builder/bundless/loaders/javascript/babel.ts
@@ -78,6 +78,7 @@ const babelTransformer: IJSTransformer = function (content) {
     filename: this.paths.fileAbsPath,
     cwd: this.paths.cwd,
     babelrc: false,
+    configFile: false,
     sourceMaps: this.config.sourcemap,
     sourceFileName: this.config.sourcemap
       ? path.relative(


### PR DESCRIPTION
修复意外识别 `babel.config.js` 配置文件的问题

Close #651 