### PR TITLE
chore: set pnpm version to 8.6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2.2.4
         with:
-          version: 8
           run_install: false
 
       - name: Get pnpm store directory

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "ts-node": "^10.9.1",
     "zx": "^4.3.0"
   },
-  "packageManager": "pnpm@7.3.0",
+  "packageManager": "pnpm@8.6.2",
   "publishConfig": {
     "access": "public"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:


### PR DESCRIPTION
问题描述：pnpm版本有问题。
`pnpm.lock`文件里面的lockfileverison是6.0。这是`~pnpm8.5.0`的默认版本，`pnpm.8.6.0`开始这个字段默认是`6.1`
![image](https://github.com/umijs/father/assets/34960995/30355f14-9d94-40ce-b932-e05222403b06)
`package.json`文件里面声明的`packageManager`是`7.3.0`，在使用`corepack`管理包管理器的时候在本仓库目录下会强制置`pnpm`为`7.3.0`，导致很多问题
![image](https://github.com/umijs/father/assets/34960995/b465d8fd-c036-4f8a-aa9a-5edf32b32246)
在ci的时候声明的`pnpm`版本为`8`会解析到最新的8版本，也就是`8.6.1`，ci的时候`pnpm`会默认加上`--frozen-lockfile`参数所以没问题，本地使用`pnpm@8.6.1`会导致lock被更改， [action链接](https://github.com/umijs/father/actions/runs/5195740784/jobs/9368752425)
![image](https://github.com/umijs/father/assets/34960995/dfea7929-021c-4555-8e00-01ddc56d0899)
解决：
先将版本统一为lock文件指定的pnpm版本，也就是`8.5.1`