### PR TITLE
feat: support pre-bundle for legacy built-in-modules

### DIFF
--- a/src/prebundler/config.ts
+++ b/src/prebundler/config.ts
@@ -10,6 +10,7 @@ import {
   getDepPkgPath,
   getDtsInfoForPkgPath,
   getNestedTypeDepsForPkg,
+  isBuiltInModule,
 } from '../utils';
 
 export interface IPreBundleConfig {
@@ -131,7 +132,8 @@ export function getConfig(opts: {
     let depName = Array.isArray(deps) ? deps[parseInt(dep)] : dep;
     depConfig = Array.isArray(deps) ? {} : depConfig;
 
-    const depEntryPath = require.resolve(depName, { paths: [opts.cwd] });
+    const depPath = isBuiltInModule(depName) ? `${depName}/` : depName;
+    const depEntryPath = require.resolve(depPath, { paths: [opts.cwd] });
     const depPkgPath = getDepPkgPath(depName, opts.cwd);
     const depTypeInfo =
       depConfig.dts !== false ? getDtsInfoForPkgPath(depPkgPath) : null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { chalk, logger as umiLogger, pkgUp } from '@umijs/utils';
 import Cache from 'file-system-cache';
+import { builtinModules } from 'module';
 import path, { isAbsolute } from 'path';
 import { CACHE_PATH } from './constants';
 import { IApi } from './types';
@@ -68,6 +69,12 @@ export function getDtsInfoForPkgPath(pkgPath: string) {
 
   return info;
 }
+
+/**
+ * Determine if it is a native module
+ */
+export const isBuiltInModule = (pkgName: string) =>
+  builtinModules.includes(pkgName.replace(/^node:/, ''));
 
 /**
  * get package.json path for specific NPM package

--- a/tests/fixtures/prebundle/builtin-module/.fatherrc.ts
+++ b/tests/fixtures/prebundle/builtin-module/.fatherrc.ts
@@ -1,0 +1,5 @@
+export default {
+  prebundle: {
+    deps: ['url'],
+  },
+};

--- a/tests/fixtures/prebundle/builtin-module/expect.ts
+++ b/tests/fixtures/prebundle/builtin-module/expect.ts
@@ -1,0 +1,5 @@
+export default (files: Record<string, string>) => {
+  // check url/index.js is exists
+  expect(files['url/index.js']).not.toBeUndefined();
+  expect(files['url/index.d.ts']).toBeUndefined();
+};

--- a/tests/fixtures/prebundle/builtin-module/package.json
+++ b/tests/fixtures/prebundle/builtin-module/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "url": "0.11.1"
+  }
+}

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,5 +1,10 @@
 import { logger as umiLogger } from '@umijs/utils';
-import { getDepPkgName, isFilePath, logger } from '../src/utils';
+import {
+  getDepPkgName,
+  isBuiltInModule,
+  isFilePath,
+  logger,
+} from '../src/utils';
 
 jest.mock('@umijs/utils', () => {
   const originalModule = jest.requireActual('@umijs/utils');
@@ -93,5 +98,11 @@ describe('logger', () => {
     test('relative', () => {
       expect(getDepPkgName('./name/test', { name: 'test' })).toBe('test');
     });
+  });
+
+  test(isBuiltInModule.name, () => {
+    expect(isBuiltInModule('node:path')).toBeTruthy();
+    expect(isBuiltInModule('path')).toBeTruthy();
+    expect(isBuiltInModule('minimatch')).toBeFalsy();
   });
 });


### PR DESCRIPTION
支持对 `url`、`util` 等跟 `builtin-module` 同名的库进行预编译。

之前会报错，因为 `require.resolve('url')` 返回的 `entry` 是 `url`， 传递给ncc会报错。