### PR TITLE
feat: upgrade typescript to ~5.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "ts-node": "^10.9.1",
     "zx": "^4.3.0"
   },
-  "packageManager": "pnpm@8.6.2",
+  "packageManager": "pnpm@8.6.9",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     ]
   },
   "dependencies": {
-    "@microsoft/api-extractor": "7.34.3",
+    "@microsoft/api-extractor": "7.36.3",
     "@umijs/babel-preset-umi": "^4.0.70",
     "@umijs/bundler-utils": "^4.0.70",
     "@umijs/bundler-webpack": "^4.0.70",
@@ -52,7 +52,6 @@
     "@vercel/ncc": "0.33.3",
     "babel-plugin-dynamic-import-node": "2.3.3",
     "babel-plugin-module-resolver": "4.1.0",
-    "babel-plugin-react-require": "3.1.3",
     "babel-plugin-transform-define": "2.0.1",
     "enhanced-resolve": "5.9.3",
     "fast-glob": "3.2.12",
@@ -60,7 +59,7 @@
     "loader-runner": "4.2.0",
     "minimatch": "3.1.2",
     "tsconfig-paths": "4.0.0",
-    "typescript": "~4.8.4",
+    "typescript": "~5.0.4",
     "typescript-transform-paths": "3.4.6",
     "v8-compile-cache": "2.3.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@microsoft/api-extractor':
-        specifier: 7.34.3
-        version: 7.34.3(@types/node@18.15.13)
+        specifier: 7.36.3
+        version: 7.36.3(@types/node@18.15.13)
       '@umijs/babel-preset-umi':
         specifier: ^4.0.70
         version: 4.0.70(styled-components@6.0.3)
@@ -19,7 +19,7 @@ importers:
         version: 4.0.70
       '@umijs/bundler-webpack':
         specifier: ^4.0.70
-        version: 4.0.70(styled-components@6.0.3)(typescript@4.8.4)(webpack@5.80.0)
+        version: 4.0.70(styled-components@6.0.3)(typescript@5.0.4)(webpack@5.80.0)
       '@umijs/case-sensitive-paths-webpack-plugin':
         specifier: ^1.0.1
         version: 1.0.1
@@ -38,9 +38,6 @@ importers:
       babel-plugin-module-resolver:
         specifier: 4.1.0
         version: 4.1.0
-      babel-plugin-react-require:
-        specifier: 3.1.3
-        version: 3.1.3
       babel-plugin-transform-define:
         specifier: 2.0.1
         version: 2.0.1
@@ -63,11 +60,11 @@ importers:
         specifier: 4.0.0
         version: 4.0.0
       typescript:
-        specifier: ~4.8.4
-        version: 4.8.4
+        specifier: ~5.0.4
+        version: 5.0.4
       typescript-transform-paths:
         specifier: 3.4.6
-        version: 3.4.6(typescript@4.8.4)
+        version: 3.4.6(typescript@5.0.4)
       v8-compile-cache:
         specifier: 2.3.0
         version: 2.3.0
@@ -119,7 +116,7 @@ importers:
         version: 2.8.7
       prettier-plugin-organize-imports:
         specifier: ^3.2.2
-        version: 3.2.2(prettier@2.8.7)(typescript@4.8.4)
+        version: 3.2.2(prettier@2.8.7)(typescript@5.0.4)
       prettier-plugin-packagejson:
         specifier: ^2.4.3
         version: 2.4.3(prettier@2.8.7)
@@ -128,7 +125,7 @@ importers:
         version: 3.0.2
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@swc/core@1.3.53)(@types/node@18.15.13)(typescript@4.8.4)
+        version: 10.9.1(@swc/core@1.3.53)(@types/node@18.15.13)(typescript@5.0.4)
       zx:
         specifier: ^4.3.0
         version: 4.3.0
@@ -1846,13 +1843,13 @@ packages:
       '@types/node': 18.15.13
       chalk: 4.1.2
       cosmiconfig: 8.1.3
-      cosmiconfig-typescript-loader: 4.3.0(@types/node@18.15.13)(cosmiconfig@8.1.3)(ts-node@10.9.1)(typescript@4.8.4)
+      cosmiconfig-typescript-loader: 4.3.0(@types/node@18.15.13)(cosmiconfig@8.1.3)(ts-node@10.9.1)(typescript@5.0.4)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.1(@swc/core@1.3.53)(@types/node@18.15.13)(typescript@4.8.4)
-      typescript: 4.8.4
+      ts-node: 10.9.1(@swc/core@1.3.53)(@types/node@18.15.13)(typescript@5.0.4)
+      typescript: 5.0.4
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -2783,32 +2780,32 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
 
-  /@microsoft/api-extractor-model@7.26.3(@types/node@18.15.13):
-    resolution: {integrity: sha512-1Y/JOkaCF5zE6P56saA0yPzEb7ZJwoF2d8fUYdzZY4I0p1gmqGbNk1h9WguvrN5hANg+2CaqcOX0eh+l4SAhJw==}
+  /@microsoft/api-extractor-model@7.27.5(@types/node@18.15.13):
+    resolution: {integrity: sha512-9/tBzYMJitR+o+zkPr1lQh2+e8ClcaTF6eZo7vZGDqRt2O5XmXWPbYJZmxyM3wb5at6lfJNEeGZrQXLjsQ0Nbw==}
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.1
-      '@rushstack/node-core-library': 3.55.1(@types/node@18.15.13)
+      '@rushstack/node-core-library': 3.59.6(@types/node@18.15.13)
     transitivePeerDependencies:
       - '@types/node'
     dev: false
 
-  /@microsoft/api-extractor@7.34.3(@types/node@18.15.13):
-    resolution: {integrity: sha512-vXpU+i/MMinVzDxbLo3of1Sx/IS5bwOZl4XrX8YyqNBXFvovEer5ex0wckWumkBErDZtLOMp3zhZfYL3W7h3cg==}
+  /@microsoft/api-extractor@7.36.3(@types/node@18.15.13):
+    resolution: {integrity: sha512-u0H6362AQq+r55X8drHx4npgkrCfJnMzRRHfQo8PMNKB8TcBnrTLfXhXWi+xnTM6CzlU/netEN8c4bq581Rnrg==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.26.3(@types/node@18.15.13)
+      '@microsoft/api-extractor-model': 7.27.5(@types/node@18.15.13)
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.1
-      '@rushstack/node-core-library': 3.55.1(@types/node@18.15.13)
-      '@rushstack/rig-package': 0.3.17
-      '@rushstack/ts-command-line': 4.13.1
+      '@rushstack/node-core-library': 3.59.6(@types/node@18.15.13)
+      '@rushstack/rig-package': 0.4.0
+      '@rushstack/ts-command-line': 4.15.1
       colors: 1.2.5
       lodash: 4.17.21
       resolve: 1.22.1
-      semver: 7.3.8
+      semver: 7.5.4
       source-map: 0.6.1
-      typescript: 4.8.4
+      typescript: 5.0.4
     transitivePeerDependencies:
       - '@types/node'
     dev: false
@@ -2905,8 +2902,8 @@ packages:
       webpack: 5.80.0(@swc/core@1.3.53)
     dev: false
 
-  /@rushstack/node-core-library@3.55.1(@types/node@18.15.13):
-    resolution: {integrity: sha512-t/nZHq4/4S3ltpYVyIsbbIqmcZx3qEe3Aaw8tI9B6XRNqCFzPxtoTopqTPTuRn8XqCtoDaSe6uMlnn7YCTu8lQ==}
+  /@rushstack/node-core-library@3.59.6(@types/node@18.15.13):
+    resolution: {integrity: sha512-bMYJwNFfWXRNUuHnsE9wMlW/mOB4jIwSUkRKtu02CwZhQdmzMsUbxE0s1xOLwTpNIwlzfW/YT7OnOHgDffLgYg==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -2919,19 +2916,19 @@ packages:
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.1
-      semver: 7.3.8
+      semver: 7.5.4
       z-schema: 5.0.3
     dev: false
 
-  /@rushstack/rig-package@0.3.17:
-    resolution: {integrity: sha512-nxvAGeIMnHl1LlZSQmacgcRV4y1EYtgcDIrw6KkeVjudOMonlxO482PhDj3LVZEp6L7emSf6YSO2s5JkHlwfZA==}
+  /@rushstack/rig-package@0.4.0:
+    resolution: {integrity: sha512-FnM1TQLJYwSiurP6aYSnansprK5l8WUK8VG38CmAaZs29ZeL1msjK0AP1VS4ejD33G0kE/2cpsPsS9jDenBMxw==}
     dependencies:
-      resolve: 1.17.0
+      resolve: 1.22.1
       strip-json-comments: 3.1.1
     dev: false
 
-  /@rushstack/ts-command-line@4.13.1:
-    resolution: {integrity: sha512-UTQMRyy/jH1IS2U+6pyzyn9xQ2iMcoUKkTcZUzOP/aaMiKlWLwCTDiBVwhw/M1crDx6apF9CwyjuWO9r1SBdJQ==}
+  /@rushstack/ts-command-line@4.15.1:
+    resolution: {integrity: sha512-EL4jxZe5fhb1uVL/P/wQO+Z8Rc8FMiWJ1G7VgnPDvdIt5GVjRfK7vwzder1CZQiX3x0PY6uxENYLNGTFd1InRQ==}
     dependencies:
       '@types/argparse': 1.0.38
       argparse: 1.0.10
@@ -3423,7 +3420,7 @@ packages:
       - supports-color
     dev: false
 
-  /@umijs/bundler-webpack@4.0.70(styled-components@6.0.3)(typescript@4.8.4)(webpack@5.80.0):
+  /@umijs/bundler-webpack@4.0.70(styled-components@6.0.3)(typescript@5.0.4)(webpack@5.80.0):
     resolution: {integrity: sha512-QHaIEFesPzFSHnIMhHui9Ru54VYwNdnO683CzSoIoBjYAIcpDsGM7Tl3hIesujbfhrZl2eCJQVc//ZJ0SEFiTw==}
     hasBin: true
     dependencies:
@@ -3440,7 +3437,7 @@ packages:
       cors: 2.8.5
       css-loader: 6.7.1(webpack@5.80.0)
       es5-imcompatible-versions: 0.1.80
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@4.8.4)(webpack@5.80.0)
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.0.4)(webpack@5.80.0)
       jest-worker: 29.4.3
       lightningcss: 1.19.0
       node-libs-browser: 2.2.1
@@ -3985,10 +3982,6 @@ packages:
       - supports-color
     dev: false
 
-  /babel-plugin-react-require@3.1.3:
-    resolution: {integrity: sha512-kDXhW2iPTL81x4Ye2aUMdEXQ56JP0sBJmRQRXJPH5FsNB7fOc/YCsHTqHv8IovPyw9Rk07gdd7MVUz8tUmRBCA==}
-    dev: false
-
   /babel-plugin-styled-components@2.1.1(styled-components@6.0.3):
     resolution: {integrity: sha512-c8lJlszObVQPguHkI+akXv8+Jgb9Ccujx0EetL7oIvwU100LxO6XAGe45qry37wUL40a5U9f23SYrivro2XKhA==}
     peerDependencies:
@@ -4493,7 +4486,7 @@ packages:
       vary: 1.1.2
     dev: false
 
-  /cosmiconfig-typescript-loader@4.3.0(@types/node@18.15.13)(cosmiconfig@8.1.3)(ts-node@10.9.1)(typescript@4.8.4):
+  /cosmiconfig-typescript-loader@4.3.0(@types/node@18.15.13)(cosmiconfig@8.1.3)(ts-node@10.9.1)(typescript@5.0.4):
     resolution: {integrity: sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
@@ -4504,8 +4497,8 @@ packages:
     dependencies:
       '@types/node': 18.15.13
       cosmiconfig: 8.1.3
-      ts-node: 10.9.1(@swc/core@1.3.53)(@types/node@18.15.13)(typescript@4.8.4)
-      typescript: 4.8.4
+      ts-node: 10.9.1(@swc/core@1.3.53)(@types/node@18.15.13)(typescript@5.0.4)
+      typescript: 5.0.4
     dev: true
 
   /cosmiconfig@7.0.1:
@@ -5531,7 +5524,7 @@ packages:
       is-callable: 1.2.4
     dev: false
 
-  /fork-ts-checker-webpack-plugin@8.0.0(typescript@4.8.4)(webpack@5.80.0):
+  /fork-ts-checker-webpack-plugin@8.0.0(typescript@5.0.4)(webpack@5.80.0):
     resolution: {integrity: sha512-mX3qW3idpueT2klaQXBzrIM/pHw+T0B/V9KHEvNrqijTq9NFnMZU6oreVxDYcf33P8a5cW+67PjodNHthGnNVg==}
     engines: {node: '>=12.13.0', yarn: '>=1.0.0'}
     peerDependencies:
@@ -5550,7 +5543,7 @@ packages:
       schema-utils: 3.1.2
       semver: 7.3.8
       tapable: 2.2.1
-      typescript: 4.8.4
+      typescript: 5.0.4
       webpack: 5.80.0(@swc/core@1.3.53)
     dev: false
 
@@ -6430,7 +6423,7 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@swc/core@1.3.53)(@types/node@18.15.13)(typescript@4.8.4)
+      ts-node: 10.9.1(@swc/core@1.3.53)(@types/node@18.15.13)(typescript@5.0.4)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -8225,7 +8218,7 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-organize-imports@3.2.2(prettier@2.8.7)(typescript@4.8.4):
+  /prettier-plugin-organize-imports@3.2.2(prettier@2.8.7)(typescript@5.0.4):
     resolution: {integrity: sha512-e97lE6odGSiHonHJMTYC0q0iLXQyw0u5z/PJpvP/3vRy6/Zi9kLBwFAbEGjDzIowpjQv8b+J04PDamoUSQbzGA==}
     peerDependencies:
       '@volar/vue-language-plugin-pug': ^1.0.4
@@ -8239,7 +8232,7 @@ packages:
         optional: true
     dependencies:
       prettier: 2.8.7
-      typescript: 4.8.4
+      typescript: 5.0.4
     dev: true
 
   /prettier-plugin-packagejson@2.4.3(prettier@2.8.7):
@@ -8590,12 +8583,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /resolve@1.17.0:
-    resolution: {integrity: sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==}
-    dependencies:
-      path-parse: 1.0.7
-    dev: false
-
   /resolve@1.19.0:
     resolution: {integrity: sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==}
     dependencies:
@@ -8712,6 +8699,14 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+
+  /semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: false
 
   /serialize-javascript@6.0.1:
     resolution: {integrity: sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==}
@@ -9338,7 +9333,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /ts-node@10.9.1(@swc/core@1.3.53)(@types/node@18.15.13)(typescript@4.8.4):
+  /ts-node@10.9.1(@swc/core@1.3.53)(@types/node@18.15.13)(typescript@5.0.4):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -9365,7 +9360,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.8.4
+      typescript: 5.0.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -9434,18 +9429,18 @@ packages:
       is-typedarray: 1.0.0
     dev: true
 
-  /typescript-transform-paths@3.4.6(typescript@4.8.4):
+  /typescript-transform-paths@3.4.6(typescript@5.0.4):
     resolution: {integrity: sha512-qdgpCk9oRHkIBhznxaHAapCFapJt5e4FbFik7Y4qdqtp6VyC3smAIPoDEIkjZ2eiF7x5+QxUPYNwJAtw0thsTw==}
     peerDependencies:
       typescript: '>=3.6.5'
     dependencies:
       minimatch: 3.1.2
-      typescript: 4.8.4
+      typescript: 5.0.4
     dev: false
 
-  /typescript@4.8.4:
-    resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
-    engines: {node: '>=4.2.0'}
+  /typescript@5.0.4:
+    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
+    engines: {node: '>=12.20'}
     hasBin: true
 
   /unbox-primitive@1.0.2:


### PR DESCRIPTION
升级 TypeScript 到 `~5.0.4`，继续维持与 `@microsoft/api-extractor` 相同的版本声明，避免同时安装多个版本的 `typescript`

Close #680 