### PR TITLE
refactor: downgrade browser targets for swc transformer

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -72,7 +72,7 @@ father 支持以下配置项。
 | ---------- | ------------- | ---------------- |
 | `browser`  | `babel`       | `{ ie: 11 }`     |
 | `browser`  | `esbuild`     | `{ chrome: 65 }` |
-| `browser`  | `swc`         | `{ chrome: 65 }` |
+| `browser`  | `swc`         | `{ ie: 11 }`     |
 | `node`     | `babel`       | `{ node: 14 }`   |
 | `node`     | `esbuild`     | `{ node: 14 }`   |
 | `node`     | `swc`         | `{ node: 14 }`   |

--- a/src/builder/utils.ts
+++ b/src/builder/utils.ts
@@ -82,7 +82,7 @@ const defaultCompileTarget: Record<
   [IFatherPlatformTypes.BROWSER]: {
     [IFatherJSTransformerTypes.BABEL]: { ie: 11 },
     [IFatherJSTransformerTypes.ESBUILD]: ['chrome65'],
-    [IFatherJSTransformerTypes.SWC]: { chrome: 65 },
+    [IFatherJSTransformerTypes.SWC]: { ie: 11 },
   },
   [IFatherPlatformTypes.NODE]: {
     [IFatherJSTransformerTypes.BABEL]: { node: 14 },


### PR DESCRIPTION
降级 SWC 作为 transformer 时 browser 产物的 targets 为 `{ ie: 11 }`，确保产物是 ES5，与 Babel 保持一致。

补充说明：esbuild 的 targets 之所以是 chrome 版本号，是因为很多高级语法它最多[只能转换到 ES6](https://esbuild.github.io/api/#target)，如果设置为 `{ ie: 11 }` 会报错，但 SWC 有这个能力，所以没必要和 esbuild 一样使用 chrome 版本号

cc @MadCcc @huarse