### PR TITLE
fix: dts lost in re-compilation if save file with same content

### DIFF
--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import tsPathsTransformer from 'typescript-transform-paths';
 import { CACHE_PATH } from '../../../constants';
 import { getCache, logger } from '../../../utils';
+import { getContentHash } from '../../utils';
 
 /**
  * get parsed tsconfig.json for specific path
@@ -105,7 +106,7 @@ export default async function getDeclarations(
         // format: {path:mtime:config}
         [file]: [
           file,
-          fs.lstatSync(file).mtimeMs,
+          getContentHash(fs.readFileSync(file, 'utf-8')),
           JSON.stringify(tsconfig.options),
         ].join(':'),
       }),
@@ -147,7 +148,7 @@ export default async function getDeclarations(
           cacheKeys[sourceFile] ||
           [
             sourceFile,
-            fs.lstatSync(sourceFile).mtimeMs,
+            getContentHash(fs.readFileSync(sourceFile, 'utf-8')),
             JSON.stringify(tsconfig.options),
           ].join(':');
 

--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -95,7 +95,7 @@ export default async function getDeclarations(
       tsconfig.options.incremental = true;
       tsconfig.options.tsBuildInfoFile = path.join(
         tscCacheDir,
-        'tsconfig.tsbuildinfo',
+        'tsc.tsbuildinfo',
       );
     }
 

--- a/src/builder/utils.ts
+++ b/src/builder/utils.ts
@@ -128,7 +128,7 @@ export function getBabelStyledComponentsOpts(pkg: IApi['pkg']) {
       const [name, org] = pkg.name.split('/').reverse();
       // hash org to make namespace clear
       const suffix = org
-        ? `-${createHash('md5').update(org).digest('hex').slice(0, 4)}`
+        ? `-${getContentHash(org, 4)}`
         : /* istanbul ignore next -- @preserve */
           '';
 
@@ -137,4 +137,8 @@ export function getBabelStyledComponentsOpts(pkg: IApi['pkg']) {
   }
 
   return opts;
+}
+
+export function getContentHash(content: string, length = 8) {
+  return createHash('md5').update(content).digest('hex').slice(0, length);
 }


### PR DESCRIPTION
修复存在持久缓存已存在且重复保存某个文件但不修改内容时，`.d.ts` 不会生成的问题，另外修改 `.tsbuildinfo` 文件的位置强行让存量项目的 tsc 缓存失效实现缓存重建。

原因是 tsc 的 incremental 模式不会生成未变更的文件，father 使用持久缓存补齐这些文件，但缓存 key 不是依据内容哈希而是文件修改时间，所以在文件重复保存时，tsc 认为文件没有变更（应该是以哈希判断？）所以不会生成，father 又从持久缓存中找不到（以时间戳查找）对应内容无法补齐文件，最终导致 `.d.ts` 丢失。

解法是 father 对 `.d.ts` 的缓存 key 改为内容哈希，确保重复保存时也能命中。

Close #669 