### PR TITLE
refactor: skip d.ts files when doctor parsing

### DIFF
--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -2,9 +2,9 @@ import { glob, lodash } from '@umijs/utils';
 import fs from 'fs';
 import path from 'path';
 import {
-  createConfigProviders,
   IBundleConfig,
   IBundlessConfig,
+  createConfigProviders,
 } from '../builder/config';
 import { DEFAULT_BUNDLESS_IGNORES } from '../constants';
 import { getConfig as getPreBundleConfig } from '../prebundler/config';
@@ -139,7 +139,7 @@ export default async (api: IApi): Promise<IDoctorReport> => {
   for (const file of sourceFiles) {
     // skip non-javascript files
     // TODO: support collect imports from style style pre-processor files
-    if (!/\.(j|t)sx?$/.test(file)) continue;
+    if (!/(?<!\.d)\.(j|t)s$/.test(file)) continue;
 
     importsReport.push(
       ...(await api.applyPlugins({

--- a/tests/fixtures/doctor/health/src/test.d.ts
+++ b/tests/fixtures/doctor/health/src/test.d.ts
@@ -1,0 +1,5 @@
+interface test {
+  // expect doctor parser skip this file
+  // @ts-expect-error
+  desensitizeCache?: <P, R = any>(params: P = any) => Promise<R>;
+}


### PR DESCRIPTION
doctor 在收集源代码文件的时候过滤掉 `.d.ts` 文件，两个原因：

1. doctor 预期是只查 JavaScript 和 TypeScript 源代码，类型文件不在目前的设计内
2. esbuid 对 `.d.ts` 文件内容的报错不如 tsc 人性化，不如交给 IDE 或交给 build 来提示