### PR TITLE
fix: d.ts may lost if tsconfig changed

### DIFF
--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -95,7 +95,7 @@ export default async function getDeclarations(
       tsconfig.options.incremental = true;
       tsconfig.options.tsBuildInfoFile = path.join(
         tscCacheDir,
-        'tsc.tsbuildinfo',
+        'dts.tsbuildinfo',
       );
     }
 
@@ -103,12 +103,10 @@ export default async function getDeclarations(
     const cacheKeys = inputFiles.reduce<Record<string, string>>(
       (ret, file) => ({
         ...ret,
-        // format: {path:mtime:config}
-        [file]: [
-          file,
-          getContentHash(fs.readFileSync(file, 'utf-8')),
-          JSON.stringify(tsconfig.options),
-        ].join(':'),
+        // format: {path:contenthash}
+        [file]: [file, getContentHash(fs.readFileSync(file, 'utf-8'))].join(
+          ':',
+        ),
       }),
       {},
     );
@@ -149,7 +147,6 @@ export default async function getDeclarations(
           [
             sourceFile,
             getContentHash(fs.readFileSync(sourceFile, 'utf-8')),
-            JSON.stringify(tsconfig.options),
           ].join(':');
 
         cacheRets[cacheKey] ??= [];
@@ -167,7 +164,7 @@ export default async function getDeclarations(
 
     const incrProgram = ts.createIncrementalProgram({
       rootNames: inputFiles,
-      options: tsconfig.options as any,
+      options: tsconfig.options,
       host: tsHost,
     });
 


### PR DESCRIPTION
修复在 tsconfig 变更后，d.ts 文件可能丢失的问题，引发该问题的上下文如下：

1. father 4.2 使用了 tsc 的 incremental 模式做增量编译，部分 tsconfig 的修改可能会被 tsc 判定为不需要重新编译
2. father 构建前默认清空输出目录，而上一条 tsc 又可能不会重新输出文件，所以 father 利用持久缓存做了文件补齐，参考 https://github.com/umijs/father/pull/649 https://github.com/umijs/father/pull/656
3. father 持久缓存的 key 由文件 path、contenthash 和 tsconfig 组成，这意味着只要 tsconfig 发生变更这份缓存就失效了，也就无法为 1 做文件不齐，导致 d.ts 文件丢失

解决方案：将 father 持久缓存 key 中的 tsconfig 去掉，缓存失效与否以 path 和 contenthash 为准；另外手动让 tsc 缓存失效，避免用户更新依赖但未删除 `node_modules/.cache` 的时候出现异常情况

这里无需担心缓存错乱的问题，几种带缓存构建的情况：
1. 文件未变 + tsconfig 变，tsc 就会重新编译输出新的产物，father 也会用这份新的结果覆盖旧的缓存
2. 文件变 + tsconfig 变，tsc 会重新编译输出新的产物，father 也会建立新的缓存
3. 文件未变 + tsconfig 未变，tsc 不会输出产物，father 会用持久缓存补齐产物

Close #698 