### PR TITLE
fix: include types lost when generating dts

### DIFF
--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -163,7 +163,7 @@ export default async function getDeclarations(
     });
 
     const incrProgram = ts.createIncrementalProgram({
-      rootNames: inputFiles,
+      rootNames: tsconfig.fileNames,
       options: tsconfig.options,
       host: tsHost,
     });

--- a/src/builder/bundless/loaders/index.ts
+++ b/src/builder/bundless/loaders/index.ts
@@ -63,17 +63,22 @@ export default async (
   const cacheRet = await cache.get(cacheKey, '');
 
   // use cache first
-  if (cacheRet)
+  if (cacheRet) {
+    const tsconfig = /\.tsx?$/.test(fileAbsPath)
+      ? getTsconfig(opts.cwd)
+      : undefined;
+
     return Promise.resolve<ILoaderOutput>({
       ...cacheRet,
       options: {
         ...cacheRet.options,
         // FIXME: shit code for avoid invalid declaration value when tsconfig changed
-        declaration: /\.tsx?$/.test(fileAbsPath)
-          ? getTsconfig(opts.cwd)?.options.declaration
-          : false,
+        declaration:
+          tsconfig?.options.declaration &&
+          tsconfig?.fileNames.includes(fileAbsPath),
       },
     });
+  }
 
   // get matched loader by test
   const matched = loaders.find((item) => {

--- a/src/builder/bundless/loaders/index.ts
+++ b/src/builder/bundless/loaders/index.ts
@@ -1,3 +1,4 @@
+import { winPath } from '@umijs/utils';
 import fs from 'fs';
 import { runLoaders } from 'loader-runner';
 import type { IApi } from '../../../types';
@@ -63,6 +64,7 @@ export default async (
   const cacheRet = await cache.get(cacheKey, '');
 
   // use cache first
+  /* istanbul ignore if -- @preserve */
   if (cacheRet) {
     const tsconfig = /\.tsx?$/.test(fileAbsPath)
       ? getTsconfig(opts.cwd)
@@ -75,7 +77,7 @@ export default async (
         // FIXME: shit code for avoid invalid declaration value when tsconfig changed
         declaration:
           tsconfig?.options.declaration &&
-          tsconfig?.fileNames.includes(fileAbsPath),
+          tsconfig?.fileNames.includes(winPath(fileAbsPath)),
       },
     });
   }

--- a/src/builder/bundless/loaders/javascript/index.ts
+++ b/src/builder/bundless/loaders/javascript/index.ts
@@ -32,9 +32,12 @@ const jsLoader: IBundlessLoader = function (content) {
   }
 
   // mark for output declaration file
+  const tsconfig = /\.tsx?$/.test(this.resource)
+    ? getTsconfig(this.context!)
+    : undefined;
   if (
-    /\.tsx?$/.test(this.resource) &&
-    getTsconfig(this.context!)?.options.declaration
+    tsconfig?.options.declaration &&
+    tsconfig?.fileNames.includes(this.resource)
   ) {
     outputOpts.declaration = true;
   }

--- a/src/builder/bundless/loaders/javascript/index.ts
+++ b/src/builder/bundless/loaders/javascript/index.ts
@@ -1,3 +1,4 @@
+import { winPath } from '@umijs/utils';
 import { getTsconfig } from '../../dts';
 import type { IBundlessLoader, IJSTransformer, ILoaderOutput } from '../types';
 
@@ -37,7 +38,7 @@ const jsLoader: IBundlessLoader = function (content) {
     : undefined;
   if (
     tsconfig?.options.declaration &&
-    tsconfig?.fileNames.includes(this.resource)
+    tsconfig?.fileNames.includes(winPath(this.resource))
   ) {
     outputOpts.declaration = true;
   }

--- a/tests/fixtures/build/bundle-alias-tsconfig/tsconfig.json
+++ b/tests/fixtures/build/bundle-alias-tsconfig/tsconfig.json
@@ -1,17 +1,7 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
-    "esModuleInterop": true,
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "target": "es2015",
-    "jsx": "react",
-    "baseUrl": ".",
+    "baseUrl": "./",
     "paths": {
       "alias-module": ["./src/alias.ts"],
       "@/*": ["./src/*"],

--- a/tests/fixtures/build/bundle-targets/src/index.ts
+++ b/tests/fixtures/build/bundle-targets/src/index.ts
@@ -2,4 +2,4 @@ async function hello() {
   return await Promise.resolve('ok');
 }
 
-hello();
+export default hello;

--- a/tests/fixtures/build/bundless-alias/tsconfig.json
+++ b/tests/fixtures/build/bundless-alias/tsconfig.json
@@ -1,8 +1,7 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "strict": true,
     "declaration": true,
-    "skipLibCheck": true,
     "baseUrl": "./",
     "paths": {
       "@/*": ["./src/*"],

--- a/tests/fixtures/build/bundless-babel-targets/src/index.ts
+++ b/tests/fixtures/build/bundless-babel-targets/src/index.ts
@@ -2,4 +2,4 @@ async function hello() {
   return await Promise.resolve('ok');
 }
 
-hello();
+export default hello;

--- a/tests/fixtures/build/bundless-diff-dts/tsconfig.json
+++ b/tests/fixtures/build/bundless-diff-dts/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "declaration": true
   }

--- a/tests/fixtures/build/bundless-esbuild-targets/src/index.ts
+++ b/tests/fixtures/build/bundless-esbuild-targets/src/index.ts
@@ -2,4 +2,4 @@ async function hello() {
   return await Promise.resolve('ok');
 }
 
-hello();
+export default hello;

--- a/tests/fixtures/build/bundless-include-dts/.fatherrc.ts
+++ b/tests/fixtures/build/bundless-include-dts/.fatherrc.ts
@@ -1,0 +1,3 @@
+export default {
+  esm: {},
+};

--- a/tests/fixtures/build/bundless-include-dts/expect.ts
+++ b/tests/fixtures/build/bundless-include-dts/expect.ts
@@ -1,0 +1,4 @@
+export default (files: Record<string, string>) => {
+  // expect global types to be included
+  expect(files['esm/index.d.js']).toContain(': string;');
+};

--- a/tests/fixtures/build/bundless-include-dts/expect.ts
+++ b/tests/fixtures/build/bundless-include-dts/expect.ts
@@ -1,4 +1,4 @@
 export default (files: Record<string, string>) => {
   // expect global types to be included
-  expect(files['esm/index.d.js']).toContain(': string;');
+  expect(files['esm/index.d.ts']).toContain(': string;');
 };

--- a/tests/fixtures/build/bundless-include-dts/global.d.ts
+++ b/tests/fixtures/build/bundless-include-dts/global.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  interface Window {
+    hello: string;
+  }
+}
+
+export {};

--- a/tests/fixtures/build/bundless-include-dts/src/index.ts
+++ b/tests/fixtures/build/bundless-include-dts/src/index.ts
@@ -1,0 +1,1 @@
+export default window.hello;

--- a/tests/fixtures/build/bundless-include-dts/tsconfig.json
+++ b/tests/fixtures/build/bundless-include-dts/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["global.d.ts", "src/**/*.ts"]
+}

--- a/tests/fixtures/build/bundless-include-dts/tsconfig.json
+++ b/tests/fixtures/build/bundless-include-dts/tsconfig.json
@@ -1,4 +1,6 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["global.d.ts", "src/**/*.ts"]
+  "compilerOptions": {
+    "declaration": true
+  }
 }

--- a/tests/fixtures/build/bundless-outer-paths/tsconfig.json
+++ b/tests/fixtures/build/bundless-outer-paths/tsconfig.json
@@ -1,9 +1,8 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "strict": true,
-    "skipLibCheck": true,
     "declaration": true,
-    "baseUrl": ".",
+    "baseUrl": "./",
     "paths": {
       "@bundless-overrides": ["../bundless-overrides/src/client"]
     }

--- a/tests/fixtures/build/bundless-swc-alias/tsconfig.json
+++ b/tests/fixtures/build/bundless-swc-alias/tsconfig.json
@@ -1,8 +1,7 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "strict": true,
     "declaration": true,
-    "skipLibCheck": true,
     "baseUrl": "./",
     "paths": {
       "@/*": ["./src/*"],

--- a/tests/fixtures/build/bundless-swc-targets/src/index.ts
+++ b/tests/fixtures/build/bundless-swc-targets/src/index.ts
@@ -2,4 +2,4 @@ async function hello() {
   return await Promise.resolve('ok');
 }
 
-hello();
+export default hello;

--- a/tests/fixtures/build/tsconfig.json
+++ b/tests/fixtures/build/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": ".",
+    "strict": true,
+    "skipLibCheck": true,
     "jsx": "react"
-  },
-  "include": ["**/*.ts", "**/*.tsx"]
+  }
 }


### PR DESCRIPTION
修复在生成 d.ts 时，通过 tsconfig include 的额外类型比如 `global.d.ts` 丢失导致编译报错的问题

Close #704 