### PR TITLE
fix: omit dts errors that not in the built files

### DIFF
--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -188,7 +188,9 @@ export default async function getDeclarations(
     // ref: https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API#a-minimal-compiler
     const diagnostics = ts
       .getPreEmitDiagnostics(incrProgram.getProgram())
-      .concat(result.diagnostics);
+      .concat(result.diagnostics)
+      // omit error for files which not included by build
+      .filter((d) => !d.file || inputFiles.includes(d.file.fileName));
 
     /* istanbul ignore if -- @preserve */
     if (diagnostics.length) {

--- a/tests/fixtures/build/bundless-omit-dts-error/.fatherrc.ts
+++ b/tests/fixtures/build/bundless-omit-dts-error/.fatherrc.ts
@@ -1,0 +1,3 @@
+export default {
+  esm: {},
+};

--- a/tests/fixtures/build/bundless-omit-dts-error/docs/error.ts
+++ b/tests/fixtures/build/bundless-omit-dts-error/docs/error.ts
@@ -1,0 +1,2 @@
+// expect omit this error, because .fatherrc not include docs folder
+window.nothing = 1;

--- a/tests/fixtures/build/bundless-omit-dts-error/expect.ts
+++ b/tests/fixtures/build/bundless-omit-dts-error/expect.ts
@@ -1,3 +1,3 @@
 export default (files: Record<string, string>) => {
-  expect(Object.keys(files)).toEqual(['index.js', 'index.d.ts']);
+  expect(Object.keys(files)).toEqual(['esm/index.js', 'esm/index.d.ts']);
 };

--- a/tests/fixtures/build/bundless-omit-dts-error/expect.ts
+++ b/tests/fixtures/build/bundless-omit-dts-error/expect.ts
@@ -1,3 +1,3 @@
 export default (files: Record<string, string>) => {
-  expect(Object.keys(files)).toEqual(['esm/index.js', 'esm/index.d.ts']);
+  expect(Object.keys(files)).toEqual(['esm/index.d.ts', 'esm/index.js']);
 };

--- a/tests/fixtures/build/bundless-omit-dts-error/expect.ts
+++ b/tests/fixtures/build/bundless-omit-dts-error/expect.ts
@@ -1,0 +1,3 @@
+export default (files: Record<string, string>) => {
+  expect(Object.keys(files)).toEqual(['index.js', 'index.d.ts']);
+};

--- a/tests/fixtures/build/bundless-omit-dts-error/src/demos/error.ts
+++ b/tests/fixtures/build/bundless-omit-dts-error/src/demos/error.ts
@@ -1,0 +1,2 @@
+// expect omit this error, because demos folder is ignored by default
+window.nothing = 1;

--- a/tests/fixtures/build/bundless-omit-dts-error/src/index.ts
+++ b/tests/fixtures/build/bundless-omit-dts-error/src/index.ts
@@ -1,0 +1,1 @@
+export default 1;

--- a/tests/fixtures/build/bundless-omit-dts-error/tsconfig.json
+++ b/tests/fixtures/build/bundless-omit-dts-error/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true
+  }
+}


### PR DESCRIPTION
d.ts 生成的时候，忽略不在 bundless 文件列表中的类型错误，比如 `demos`、`config` 之类的

动机：father 仅抛出影响产物的类型错误，项目全量的类型错误仍然是 tsc 的职责，否则会引起多数项目构建失败

Close #710 