### PR TITLE
feat: add TSCONFIG_RISK doctor rule

### DIFF
--- a/docs/guide/doctor.md
+++ b/docs/guide/doctor.md
@@ -39,6 +39,15 @@ $ father doctor
 
 源码中引入路径的文件大小写与磁盘上的大小写不符，如果开发者使用的是大小写不敏感的操作系统（比如 Windows 和 macOS 的默认配置），由于编译不会报错，可能不会发现该问题，但 NPM 包发布后在大小写敏感的操作系统上编译时则会找不到模块。
 
+## TSCONFIG_RISK
+
+- 级别：错误 ❌
+- 说明：
+
+检查 tsconfig.json 配置中存在的风险，目前支持检测如下风险：
+
+1. 当 `compilerOptions.declaration` 启用时，如果配置了 `include` 且没有包含任何 bundless 构建的源文件，则认定为存在 `.d.ts` 产物缺失风险，会进行报错
+
 ## PREFER_PACK_FILES
 
 - 级别：警告 ⚠️
@@ -77,4 +86,3 @@ $ father doctor
 - 说明：
 
 有多实例风险的依赖声明应该放入 `peerDependencies` 而不是 `dependencies`，比如 `react`、`antd`。
-

--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -7,13 +7,24 @@ import { getCache, logger } from '../../../utils';
 import { getContentHash } from '../../utils';
 
 /**
+ * get tsconfig.json path for specific path
+ */
+export function getTsconfigPath(cwd: string) {
+  // use require() rather than import(), to avoid jest runner to fail
+  // ref: https://github.com/nodejs/node/issues/35889
+  const ts: typeof import('typescript') = require('typescript');
+
+  return ts.findConfigFile(cwd, ts.sys.fileExists);
+}
+
+/**
  * get parsed tsconfig.json for specific path
  */
 export function getTsconfig(cwd: string) {
   // use require() rather than import(), to avoid jest runner to fail
   // ref: https://github.com/nodejs/node/issues/35889
   const ts: typeof import('typescript') = require('typescript');
-  const tsconfigPath = ts.findConfigFile(cwd, ts.sys.fileExists);
+  const tsconfigPath = getTsconfigPath(cwd);
 
   if (tsconfigPath) {
     const tsconfigFile = ts.readConfigFile(tsconfigPath, ts.sys.readFile);

--- a/src/doctor/rules/TSCONFIG_RISK.ts
+++ b/src/doctor/rules/TSCONFIG_RISK.ts
@@ -1,0 +1,31 @@
+import { winPath } from '@umijs/utils';
+import path from 'path';
+import { getTsconfig, getTsconfigPath } from '../../builder/bundless/dts';
+import type { IApi } from '../../types';
+
+export default (api: IApi) => {
+  api.addRegularCheckup(({ bundlessConfigs }) => {
+    if (bundlessConfigs.length) {
+      const tsconfigPath = getTsconfigPath(api.cwd);
+      // only check when tsconfig.json is in cwd
+      const tsconfig = tsconfigPath?.includes(api.cwd) && getTsconfig(api.cwd);
+
+      if (tsconfig && tsconfig.options.declaration) {
+        const inputs = bundlessConfigs.map((c) => c.input);
+        const files = tsconfig.fileNames.map((f) =>
+          winPath(path.relative(api.cwd, f)),
+        );
+
+        if (files.every((f) => inputs.every((i) => !f.startsWith(i)))) {
+          return {
+            type: 'error',
+            problem:
+              'No source file included in tsconfig.json, so even if the `declaration` option is enabled, no `.d.ts` dist files will be generated',
+            solution:
+              "Add source directory to tsconfig.json `include` option, or disable the `declaration` option if you don't need `.d.ts` dist files",
+          };
+        }
+      }
+    }
+  });
+};

--- a/src/doctor/rules/TSCONFIG_RISK.ts
+++ b/src/doctor/rules/TSCONFIG_RISK.ts
@@ -8,7 +8,8 @@ export default (api: IApi) => {
     if (bundlessConfigs.length) {
       const tsconfigPath = getTsconfigPath(api.cwd);
       // only check when tsconfig.json is in cwd
-      const tsconfig = tsconfigPath?.includes(api.cwd) && getTsconfig(api.cwd);
+      const tsconfig =
+        tsconfigPath?.includes(winPath(api.cwd)) && getTsconfig(api.cwd);
 
       if (tsconfig && tsconfig.options.declaration) {
         const inputs = bundlessConfigs.map((c) => c.input);

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -97,7 +97,7 @@ test('doctor: error checkups', async () => {
 
   // TSCONFIG_RISK
   expect(console.log).toHaveBeenCalledWith(
-    expect.stringContaining('No source files included in tsconfig.json'),
+    expect.stringContaining('No source file included in tsconfig.json'),
   );
 
   // CJS_IMPORT_PURE_ESM

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -95,6 +95,11 @@ test('doctor: error checkups', async () => {
     );
   }
 
+  // TSCONFIG_RISK
+  expect(console.log).toHaveBeenCalledWith(
+    expect.stringContaining('No source files included in tsconfig.json'),
+  );
+
   // CJS_IMPORT_PURE_ESM
   // expect(console.log).toHaveBeenCalledWith(
   //   expect.stringContaining('ERR_REQUIRE_ESM'),

--- a/tests/fixtures/doctor/errors/tsconfig.json
+++ b/tests/fixtures/doctor/errors/tsconfig.json
@@ -1,1 +1,6 @@
-{}
+{
+  "compilerOptions": {
+    "declaration": true
+  },
+  "include": [".fatherrc.ts"]
+}


### PR DESCRIPTION
新增 `TSCONFIG_RISK` doctor 规则，用于检查 tsconfig.json 配置中存在的风险，目前支持检测如下风险：

1. 当 `compilerOptions.declaration` 启用时，如果配置了 `include` 且没有包含任何 bundless 构建的源文件，则认定为存在 `.d.ts` 产物缺失风险，会进行报错

动机：主要是为了消除 #704  带来的负面影响，答疑中碰到了有项目的 `include` 配置项里包含源码目录，但又在消费 `.d.ts` 产物的情况，升级到 4.3.3 后会出现 `.d.ts` 产物缺失，所以利用 doctor 规则做一层拦截