### PR TITLE
fix: tsconfig paths has type error if out of cwd

### DIFF
--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -188,13 +188,11 @@ export default async function getDeclarations(
     // ref: https://github.com/LeDDGroup/typescript-transform-paths/blob/06c317839ca2f2426ad5c39c640e231f739af115/src/transformer.ts#L136-L140
     const proxyTs = new Proxy(ts, {
       get(target: any, prop) {
+        // typescript internal method since 4.4.x
         const PROXY_KEY = 'tryParsePatterns';
 
         return prop === PROXY_KEY
-          ? () =>
-              PROXY_KEY in target
-                ? target.tryParsePatterns(transformPaths)
-                : target.getOwnKeys(transformPaths)
+          ? () => target[PROXY_KEY](transformPaths)
           : target[prop];
       },
     });

--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -56,6 +56,7 @@ export default async function getDeclarations(
   // ref: https://github.com/nodejs/node/issues/35889
   const ts: typeof import('typescript') = require('typescript');
   const tsconfig = getTsconfig(opts.cwd);
+  const transformPaths: Record<string, string[]> = {};
 
   if (tsconfig) {
     // check tsconfig error
@@ -94,10 +95,11 @@ export default async function getDeclarations(
         tsconfig.options.paths![item][0],
       );
 
-      if (!winPath(pathAbsTarget).startsWith(`${winPath(opts.cwd)}/`)) {
-        delete tsconfig.options.paths![item];
+      if (winPath(pathAbsTarget).startsWith(`${winPath(opts.cwd)}/`)) {
+        transformPaths[item] = tsconfig.options.paths![item];
+      } else {
         logger.debug(
-          `Remove ${item} from tsconfig.paths, because it's out of cwd.`,
+          `Skip transform ${item} from tsconfig.paths, because it's out of cwd.`,
         );
       }
     });
@@ -182,6 +184,20 @@ export default async function getDeclarations(
     // using ts-paths-transformer to transform tsconfig paths to relative path
     // reason: https://github.com/microsoft/TypeScript/issues/30952
     // ref: https://www.npmjs.com/package/typescript-transform-paths
+    // proxy pathsPatterns to avoid transform paths out of cwd
+    // ref: https://github.com/LeDDGroup/typescript-transform-paths/blob/06c317839ca2f2426ad5c39c640e231f739af115/src/transformer.ts#L136-L140
+    const proxyTs = new Proxy(ts, {
+      get(target: any, prop) {
+        const PROXY_KEY = 'tryParsePatterns';
+
+        return prop === PROXY_KEY
+          ? () =>
+              PROXY_KEY in target
+                ? target.tryParsePatterns(transformPaths)
+                : target.getOwnKeys(transformPaths)
+          : target[prop];
+      },
+    });
     const result = incrProgram.emit(undefined, undefined, undefined, true, {
       afterDeclarations: [
         tsPathsTransformer(
@@ -190,7 +206,7 @@ export default async function getDeclarations(
           // specific typescript instance, because this plugin is incompatible with typescript@4.9.x currently
           // but some project may declare typescript and some dependency manager will hoist project's typescript
           // rather than father's typescript for this plugin
-          { ts },
+          { ts: proxyTs },
         ),
       ],
     });


### PR DESCRIPTION
修复超出 cwd 的 tsconfig `paths` 会出现模块找不到的类型错误的问题。

背景是 father 会在 d.ts 生成的时候自动替换 cwd 内的 `paths` 为相对路径，确保 d.ts 产物中的路径是可以被 resolve 的；但同时又会保留 cwd 之外的 `paths`，因为 monorepo 场景下会引用其他的子包，不能用相对路径去 resolve。

问题原因是之前 father 排除 cwd 之外的方式是把 tsconfig 中的部分 `paths` 删掉后再给 ts compiler，最后由 ts 插件来转换，但这其实会引起 `paths` 对应模块找不到的错误，而之前没报错是因为 4.3.2 之前有很多错误没抛出，ref: #701 。

解决方案是 father 保留原始的 tsconfig `paths` 给 ts compiler 确保编译过程中的类型完整，但对 ts 插件消费的 `paths` 做特殊处理，排除掉 cwd 之外的 paths。