### PR TITLE
fix: type roots behavior is inconsistent with tsc

### DIFF
--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -19,6 +19,7 @@ export function getTsconfigPath(cwd: string) {
 
 /**
  * get parsed tsconfig.json for specific path
+ * ref: https://github.com/privatenumber/get-tsconfig#how-can-i-use-typescript-to-parse-tsconfigjson
  */
 export function getTsconfig(cwd: string) {
   // use require() rather than import(), to avoid jest runner to fail
@@ -32,6 +33,10 @@ export function getTsconfig(cwd: string) {
       tsconfigFile.config,
       ts.sys,
       path.dirname(tsconfigPath),
+      undefined,
+      // specify config file path like tsc, to ensure type roots behavior same as tsc
+      // ref: https://github.com/microsoft/TypeScript/blob/0464e91c8b67579a4ed840e5783575a493c958e0/src/compiler/program.ts#L2325
+      tsconfigPath,
     );
   }
 }


### PR DESCRIPTION
修复解析 `typeRoots` 的默认行为与 tsc 不一致的问题。

问题触发的情形：在 monorepo 使用根目录 tsconfig.json 的情况下，tsc 的 `typeRoots` 默认从根目录开始解析，仅包含根目录的 `node_modules/@types`，但 father 由于没有指定 `configFilePath` 则会从 cwd 开始解析，将会包含子包的 `node_modules/@types`，与 tsc 的差异行为会导致某些 IDE 不报错的情形但 father d.ts 生成报错，详细 case 可参考下方 issue。

Close #713 