### PR TITLE
fix: dts may lost if another dts has error in last time

### DIFF
--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -195,6 +195,12 @@ export default async function getDeclarations(
       ],
     });
 
+    // save cache
+    // why save cache before check compile error?
+    // because ts compiler will compile files incrementally in the next time, so the correct d.ts files may lost if not save cache
+    // and don't worry the wrong d.ts save to cache, it will be override by the new content in the next time
+    Object.keys(cacheRets).forEach((key) => cache.setSync(key, cacheRets[key]));
+
     // check compile error
     // ref: https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API#a-minimal-compiler
     const diagnostics = ts
@@ -232,9 +238,6 @@ export default async function getDeclarations(
       });
       throw new Error('Declaration generation failed.');
     }
-
-    // save cache
-    Object.keys(cacheRets).forEach((key) => cache.setSync(key, cacheRets[key]));
   }
 
   return output;


### PR DESCRIPTION
修复前序 d.ts 编译失败时部分 d.ts 丢失的问题。

原因是 father 启用了 ts 的 incremental 特性，它会自动增量编译文件，即便前序 d.ts 编译时部分源代码的类型有误，在第二次编译时它也会尽可能少地重新编译文件；father 会用持久缓存对这些不再重复编译的 d.ts 做补齐，但缓存写入逻辑仅在不存在类型诊断错误时才会执行，和 ts 的 incremental 行为不一致，最终导致产物中丢失部分 d.ts 文件。

解法是把写缓存的逻辑提前到检查类型诊断错误之前，无论如何都写入缓存。

cc @zombieJ 