### PR TITLE
refactor: use hash instead mtime for cache key

### DIFF
--- a/src/builder/bundle/index.ts
+++ b/src/builder/bundle/index.ts
@@ -24,16 +24,16 @@ export interface IBundleWatcher {
   close: () => void;
 }
 
-interface IBundlessOpts {
+interface IBundleOpts {
   cwd: string;
   configProvider: BundleConfigProvider;
   buildDependencies?: string[];
   watch?: boolean;
 }
 
-function bundless(opts: Omit<IBundlessOpts, 'watch'>): Promise<void>;
-function bundless(opts: IBundlessOpts): Promise<IBundleWatcher>;
-async function bundless(opts: IBundlessOpts): Promise<void | IBundleWatcher> {
+function bundle(opts: Omit<IBundleOpts, 'watch'>): Promise<void>;
+function bundle(opts: IBundleOpts): Promise<IBundleWatcher>;
+async function bundle(opts: IBundleOpts): Promise<void | IBundleWatcher> {
   const enableCache = process.env.FATHER_CACHE !== 'none';
   const closeHandlers: webpack.Watching['close'][] = [];
 
@@ -192,4 +192,4 @@ async function bundless(opts: IBundlessOpts): Promise<void | IBundleWatcher> {
   }
 }
 
-export default bundless;
+export default bundle;

--- a/src/builder/bundless/loaders/index.ts
+++ b/src/builder/bundless/loaders/index.ts
@@ -4,6 +4,7 @@ import { runLoaders } from 'loader-runner';
 import type { IApi } from '../../../types';
 import { getCache } from '../../../utils';
 import type { IBundlessConfig } from '../../config';
+import { getContentHash } from '../../utils';
 import { getTsconfig } from '../dts';
 import type { IBundlessLoader, ILoaderOutput } from './types';
 
@@ -51,10 +52,10 @@ export default async (
   },
 ) => {
   const cache = getCache('bundless-loader');
-  // format: {path:mtime:config:pkgDeps}
+  // format: {path:contenthash:config:pkgDeps}
   const cacheKey = [
     fileAbsPath,
-    fs.statSync(fileAbsPath).mtimeMs,
+    getContentHash(fs.readFileSync(fileAbsPath, 'utf-8')),
     JSON.stringify(opts.config),
     // use for babel opts generator in src/builder/utils.ts
     JSON.stringify(

--- a/src/doctor/parser.ts
+++ b/src/doctor/parser.ts
@@ -4,6 +4,7 @@ import {
 } from '@umijs/bundler-utils/compiled/esbuild';
 import fs from 'fs';
 import path from 'path';
+import { getContentHash } from '../builder/utils';
 import { getCache } from '../utils';
 
 export type IDoctorSourceParseResult = {
@@ -14,8 +15,11 @@ export default async (
   fileAbsPath: string,
 ): Promise<IDoctorSourceParseResult> => {
   const cache = getCache('doctor-parser');
-  // format: {path:mtime}
-  const cacheKey = [fileAbsPath, fs.statSync(fileAbsPath).mtimeMs].join(':');
+  // format: {path:contenthash}
+  const cacheKey = [
+    fileAbsPath,
+    getContentHash(fs.readFileSync(fileAbsPath, 'utf-8')),
+  ].join(':');
   const cacheRet = cache.getSync(cacheKey, '');
   const ret: IDoctorSourceParseResult = { imports: [] };
 


### PR DESCRIPTION
使用 content hash 作为缓存键，替代原有的 mtime，这样 CI 环境也可以将 cache 复用

顺便修正了 bundle 模块源码中的变量名，由于不影响用户使用就不新开 PR 处理了，Close #709 