### PR TITLE
feat: support --no-clean for dev command

### DIFF
--- a/examples/normal/package.json
+++ b/examples/normal/package.json
@@ -3,6 +3,7 @@
     "build": "father build",
     "build:no-clean": "father build --no-clean",
     "dev": "father dev",
+    "dev:no-clean": "father dev --no-clean",
     "doctor": "father doctor",
     "version": "father version"
   },

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -7,12 +7,16 @@ export default (api: IApi) => {
   api.registerCommand({
     name: DEV_COMMAND,
     description: 'start incremental build in watch mode',
-    async fn() {
+    options: `
+--no-clean  do not clean all output directories before dev
+`,
+    async fn({ args }) {
       const buildWatcher = await builder({
         userConfig: api.config,
         cwd: api.cwd,
         pkg: api.pkg,
         watch: true,
+        clean: args.clean,
       });
 
       // handle config change


### PR DESCRIPTION
目前开发场景下可能会存在不需要`clean dist`目录的情况，正如https://github.com/umijs/father/issues/693#issuecomment-1674457219 所言当我在umi项目中对father的构建产物进行联调时，father的重新启动dev会造成umi的程序崩溃。

在某些重启father dev的场景下可能没有对`umirc`配置进行改变，所以不想把umi的服务关掉再启动，这会省一些时间。

Close https://github.com/umijs/father/issues/693