### PR TITLE
fix: bundless cache maybe broken if has dts error

### DIFF
--- a/src/builder/bundless/loaders/index.ts
+++ b/src/builder/bundless/loaders/index.ts
@@ -129,8 +129,9 @@ export default async (
             };
 
             // save cache then resolve
-            cache.set(cacheKey, ret);
-            resolve(ret);
+            cache.set(cacheKey, ret).then(() => {
+              resolve(ret);
+            });
           } else {
             resolve(void 0);
           }

--- a/src/doctor/parser.ts
+++ b/src/doctor/parser.ts
@@ -56,7 +56,7 @@ export default async (
     ],
   });
 
-  cache.set(cacheKey, ret);
+  await cache.set(cacheKey, ret);
 
   return ret;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { chalk, logger as umiLogger, pkgUp } from '@umijs/utils';
+import { chalk, pkgUp, logger as umiLogger } from '@umijs/utils';
 import Cache from 'file-system-cache';
 import { builtinModules } from 'module';
 import path, { isAbsolute } from 'path';
@@ -13,7 +13,8 @@ const caches: Record<string, ReturnType<typeof Cache>> = {};
 export function getCache(ns: string): (typeof caches)['0'] {
   // return fake cache if cache disabled
   if (process.env.FATHER_CACHE === 'none') {
-    return { set() {}, get() {}, setSync() {}, getSync() {} } as any;
+    const deferrer = () => Promise.resolve();
+    return { set: deferrer, get: deferrer, setSync() {}, getSync() {} } as any;
   }
   return (caches[ns] ??= Cache({ basePath: path.join(CACHE_PATH, ns) }));
 }


### PR DESCRIPTION
修复 bundless 的持久缓存可能损坏导致下一次构建直接报错的问题

原因是写缓存的操作是异步进行的，会出现在内容还未完全写入文件系统的时候就遇到 dts error 进程退出，导致缓存内容不可用；解决方案是 bundless loader 处理文件时，等缓存完全写入后再 resolve，这样 dts 始终作为 loader 的后置逻辑执行，即便异常终止也不会影响 loader 缓存的有效性

cc @hualigushi 