### PR TITLE
fix: correct umd cache directory

### DIFF
--- a/src/builder/bundle/index.ts
+++ b/src/builder/bundle/index.ts
@@ -81,6 +81,10 @@ async function bundle(opts: IBundleOpts): Promise<void | IBundleWatcher> {
         jsMinifier: JSMinifier.terser,
         cssMinifier: CSSMinifier.cssnano,
         extraBabelIncludes: [/node_modules/],
+
+        // set cache parent directory, will join it with `bundler-webpack`
+        // ref: https://github.com/umijs/umi/blob/8dad8c5af0197cd62db11f4b4c85d6bc1db57db1/packages/bundler-webpack/src/build.ts#L32
+        cacheDirectoryPath: CACHE_PATH,
       },
       entry: {
         [path.parse(config.output.filename).name]: path.join(
@@ -159,7 +163,6 @@ async function bundle(opts: IBundleOpts): Promise<void | IBundleWatcher> {
         ? {
             cache: {
               buildDependencies: opts.buildDependencies,
-              cacheDirectory: path.join(opts.cwd, CACHE_PATH, 'bundle-webpack'),
             },
           }
         : {}),


### PR DESCRIPTION
修正 umd 构建持久缓存的位置，从 `node_modules/.cache/bundler-webpack` 修正为 `node_modules/.cache/father/bundler-webpack`，之前的配置方式不对所以自定义缓存位置没有生效

为什么要改目录？方便统一管理以及避免与 umi 项目一起使用时出现冲突

cc @hualigushi 