### PR TITLE
fix: ignore fs-specific tmp files in watch mode

### DIFF
--- a/src/builder/bundless/index.ts
+++ b/src/builder/bundless/index.ts
@@ -14,10 +14,10 @@ import {
   DEFAULT_BUNDLESS_IGNORES,
   WATCH_DEBOUNCE_STEP,
 } from '../../constants';
+import { logger } from '../../utils';
 import type { BundlessConfigProvider } from '../config';
 import getDeclarations from './dts';
 import runLoaders from './loaders';
-import { logger } from '../../utils';
 
 const debugLog = debug(DEBUG_BUNDLESS_NAME);
 
@@ -203,6 +203,12 @@ async function bundless(
         cwd: opts.cwd,
         ignoreInitial: true,
         ignored: DEFAULT_BUNDLESS_IGNORES,
+        // to avoid catch temp file from some special file-system
+        // ex. a.txt => a.txt.12344345 in CloudIDE
+        awaitWriteFinish: {
+          stabilityThreshold: 20,
+          pollInterval: 10,
+        },
       })
       .on('add', handleTransform)
       .on('change', handleTransform)


### PR DESCRIPTION
修复在某些特殊文件系统（比如 CloudIDE）中会 watch 到临时文件，然后尝试读取导致报错的问题，错误类似：

```bash
error - ENOENT: no such file or directory, open '/path/to/index.tsx.450062575'
```

解法是使用 `awaitWriteFinish` 等文件稳定了再触发事件，目前检测时间间隔设置得很小，所以对 watch 性能的影响应该较小