### PR TITLE
fix: wrong doctor missing rule result for prebundle dts files

### DIFF
--- a/src/doctor/rules/PACK_FILES_MISSING.ts
+++ b/src/doctor/rules/PACK_FILES_MISSING.ts
@@ -21,7 +21,7 @@ export default (api: IApi) => {
         );
         Object.values(preBundleConfig.dts).forEach((c) =>
           entities.push(
-            winPath(path.relative(api.cwd, path.basename(c.output))),
+            winPath(path.relative(api.cwd, path.dirname(c.output))),
           ),
         );
 


### PR DESCRIPTION
修复 `father doctor` 的 `PACK_FILES_MISSING` 规则在扫描 prebundle 的 dts 产物时出现错误结果的问题