### PR TITLE
fix: doctor import checkups is not work for jsx and tsx files

### DIFF
--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -139,7 +139,7 @@ export default async (api: IApi): Promise<IDoctorReport> => {
   for (const file of sourceFiles) {
     // skip non-javascript files
     // TODO: support collect imports from style style pre-processor files
-    if (!/(?<!\.d)\.(j|t)s$/.test(file)) continue;
+    if (!/(?<!\.d)\.(j|t)sx?$/.test(file)) continue;
 
     importsReport.push(
       ...(await api.applyPlugins({

--- a/tests/fixtures/doctor/errors/src/component.tsx
+++ b/tests/fixtures/doctor/errors/src/component.tsx
@@ -1,0 +1,1 @@
+export { default } from './CamelCase'

--- a/tests/fixtures/doctor/errors/src/index.ts
+++ b/tests/fixtures/doctor/errors/src/index.ts
@@ -3,10 +3,10 @@ import orgAlias from '@org/alias';
 import orgExternals from '@org/externals';
 import alias from 'alias';
 import path from 'child_process';
+import esm from 'esm';
 import externals from 'externals';
 import hello from 'hello';
-import BigCamelCase from './CamelCase';
-import esm from 'esm';
+import component from './component';
 import './index.less';
 
 // to avoid esbuild tree-shaking
@@ -17,6 +17,6 @@ console.log(
   externals,
   orgExternals,
   path,
-  BigCamelCase,
+  component,
   esm,
 );


### PR DESCRIPTION
修复 docker 检查中的 import 相关规则对 `tsx` 和 `jsx` 文件不生效的问题