### PR TITLE
chore: lock esbuild@0.17.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "babel-plugin-styled-components": "2.1.4",
     "babel-plugin-transform-define": "2.0.1",
     "enhanced-resolve": "5.9.3",
+    "esbuild": "0.17.19",
     "fast-glob": "3.2.12",
     "file-system-cache": "2.0.0",
     "loader-runner": "4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       enhanced-resolve:
         specifier: 5.9.3
         version: 5.9.3
+      esbuild:
+        specifier: 0.17.19
+        version: 0.17.19
       fast-glob:
         specifier: 3.2.12
         version: 3.2.12
@@ -3510,7 +3513,7 @@ packages:
       react-refresh: 0.14.0
       schema-utils: 3.1.2
       source-map: 0.7.4
-      webpack: 5.80.0(@swc/core@1.3.53)
+      webpack: 5.80.0(@swc/core@1.3.53)(esbuild@0.17.19)
     dev: false
 
   /@umijs/test@4.0.68(@babel/core@7.21.3):
@@ -4649,7 +4652,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.31)
       postcss-value-parser: 4.2.0
       semver: 7.5.4
-      webpack: 5.80.0(@swc/core@1.3.53)
+      webpack: 5.80.0(@swc/core@1.3.53)(esbuild@0.17.19)
     dev: false
 
   /css-prefers-color-scheme@6.0.3(postcss@8.4.31):
@@ -5573,7 +5576,7 @@ packages:
       semver: 7.5.4
       tapable: 2.2.1
       typescript: 5.3.3
-      webpack: 5.80.0(@swc/core@1.3.53)
+      webpack: 5.80.0(@swc/core@1.3.53)(esbuild@0.17.19)
     dev: false
 
   /form-data@3.0.1:
@@ -9227,7 +9230,7 @@ packages:
       supports-hyperlinks: 2.2.0
     dev: true
 
-  /terser-webpack-plugin@5.3.7(@swc/core@1.3.53)(webpack@5.80.0):
+  /terser-webpack-plugin@5.3.7(@swc/core@1.3.53)(esbuild@0.17.19)(webpack@5.80.0):
     resolution: {integrity: sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -9245,11 +9248,12 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.17
       '@swc/core': 1.3.53
+      esbuild: 0.17.19
       jest-worker: 27.5.1
       schema-utils: 3.1.2
       serialize-javascript: 6.0.1
       terser: 5.17.1
-      webpack: 5.80.0(@swc/core@1.3.53)
+      webpack: 5.80.0(@swc/core@1.3.53)(esbuild@0.17.19)
     dev: false
 
   /terser@5.17.1:
@@ -9656,7 +9660,7 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: false
 
-  /webpack@5.80.0(@swc/core@1.3.53):
+  /webpack@5.80.0(@swc/core@1.3.53)(esbuild@0.17.19):
     resolution: {integrity: sha512-OIMiq37XK1rWO8mH9ssfFKZsXg4n6klTEDL7S8/HqbAOBBaiy8ABvXvz0dDCXeEF9gqwxSvVk611zFPjS8hJxA==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -9687,7 +9691,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.2
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.7(@swc/core@1.3.53)(webpack@5.80.0)
+      terser-webpack-plugin: 5.3.7(@swc/core@1.3.53)(esbuild@0.17.19)(webpack@5.80.0)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/src/builder/bundless/loaders/javascript/esbuild.ts
+++ b/src/builder/bundless/loaders/javascript/esbuild.ts
@@ -1,5 +1,5 @@
-import { build } from '@umijs/bundler-utils/compiled/esbuild';
 import { winPath } from '@umijs/utils';
+import { build } from 'esbuild';
 import path from 'path';
 import { IFatherBundlessConfig } from '../../../../types';
 import { getBundlessTargets } from '../../../utils';


### PR DESCRIPTION
不再从 umi/bundler-utils 引入 esbuilder , 因为umijs 升级 esbuilder -> 0.2+ 后产物与 0.17+ 存在差异, 无法运行.