### PR TITLE
fix: doctor PHANTOM_DEPS rule cannot works with node:*

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.4
+        uses: pnpm/action-setup@v4
         with:
           run_install: false
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -204,7 +204,7 @@ export function isFilePath(path: string) {
 }
 
 export function getPkgNameFromPath(p: string) {
-  return p.match(/^(?:@[a-z\d][\w-.]*\/)?[a-z\d][\w-.]*/i)?.[0];
+  return p.match(/^(?:@[a-z\d][\w-.]*\/|node:)?[a-z\d][\w-.]*/i)?.[0];
 }
 
 export const getDepPkgName = (name: string, packageJson: { name: string }) => {

--- a/tests/fixtures/doctor/health/src/index.ts
+++ b/tests/fixtures/doctor/health/src/index.ts
@@ -1,3 +1,6 @@
 // expect handle pkg name includes .
 import 'hello.world';
 import 'optional';
+
+// expect pass for Node.js standard library
+import 'node:fs';


### PR DESCRIPTION
修复 `PHANTOM_DEPS` 不支持 Node.js 内置模块的问题，现在遇到 `node:fs` 的引入会判定为幽灵依赖