### PR TITLE
fix: doctor parser error

### DIFF
--- a/src/doctor/parser.ts
+++ b/src/doctor/parser.ts
@@ -30,6 +30,7 @@ export default async (
     write: false,
     // enable bundle for trigger onResolve hook, but all deps will be externalized
     bundle: true,
+    loader: { '.js': 'jsx' },
     logLevel: 'silent',
     format: 'esm',
     target: 'esnext',


### PR DESCRIPTION
复现仓库：https://github.com/hualigushi/react-js
问题描述：当一个文件后缀名是 js , 文件内容包含 jsx 语法时，doctor 命令会报错，但是 dev build 均没有报错
<img width="897" alt="截屏2025-04-22 14 05 55" src="https://github.com/user-attachments/assets/0efee0d9-12b1-482b-8a2f-fbdc193b5d88" />
