### PR TITLE
feat: add transformRuntime config for bundle builder

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -213,6 +213,13 @@ export default {
 
 指定产物的输出目录及输出文件名，输出目录的默认值为 `dist/umd`，输出文件名在单 `entry` 时默认以 NPM 包名命名、多 `entry` 时默认与源码文件同名。
 
+#### transformRuntime
+
+- 类型：`{ absoluteRuntime?: string }`
+- 默认值：`{}`
+
+配置 transform-runtime 插件的部分功能。
+
 #### externals
 
 - 类型：`Record<string, string>`

--- a/src/builder/bundle/index.ts
+++ b/src/builder/bundle/index.ts
@@ -106,7 +106,7 @@ async function bundle(opts: IBundleOpts): Promise<void | IBundleWatcher> {
               opts.cwd,
             ),
             presetTypeScript: {},
-            pluginTransformRuntime: {},
+            pluginTransformRuntime: config.transformRuntime || {},
             pluginLockCoreJS: {},
             pluginDynamicImportNode: false,
           },

--- a/src/features/configPlugins/schema.ts
+++ b/src/features/configPlugins/schema.ts
@@ -65,6 +65,9 @@ export function getSchemas(): Record<string, (Joi: Root) => any> {
           Joi.array(),
         ),
         generateUnminified: Joi.boolean().optional(),
+        transformRuntime: Joi.object({
+          absoluteRuntime: Joi.string().optional(),
+        }).optional(),
         chainWebpack: Joi.function().optional(),
         extractCSS: Joi.boolean().optional(),
         name: Joi.string().optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,16 @@ export interface IFatherBaseConfig {
   extraBabelPlugins?: IBundlerWebpackConfig['extraBabelPlugins'];
 
   /**
+   * configure transform runtime
+   */
+  transformRuntime?: {
+    /**
+     * absolute dir path which contains @babel/runtime
+     */
+    absoluteRuntime?: string;
+  };
+
+  /**
    * output sourcemap
    */
   sourcemap?: boolean;


### PR DESCRIPTION
Ref:
https://github.com/ant-design/x/pull/229
https://github.com/umijs/umi/issues/12803

cc @afc163 

---

Config.

```ts
export default {
  umd: {
    transformRuntime: {
      absoluteRuntime: process.cwd(),
    },
  }
}
```

Before:

<img width="1288" alt="image" src="https://github.com/user-attachments/assets/09a331b7-e645-4be4-a55f-d7010c70a9f5" />

After:

<img width="1294" alt="image" src="https://github.com/user-attachments/assets/522a7668-fb69-4012-abba-0002a30aace5" />

