### PR TITLE
feat: support config.copy

### DIFF
--- a/examples/utoo-pack/.fatherrc.ts
+++ b/examples/utoo-pack/.fatherrc.ts
@@ -22,7 +22,14 @@ export default defineConfig({
     },
     alias: {
       'hello-a': './src/a.ts',
+      'alias-module': path.join(__dirname, 'src/alias'),
     },
+    copy: [
+      {
+        from: './src/reset.css',
+        to: './reset.css',
+      },
+    ],
   },
   platform: 'browser',
 });

--- a/examples/utoo-pack/src/alias.ts
+++ b/examples/utoo-pack/src/alias.ts
@@ -1,0 +1,1 @@
+console.log('alias here');

--- a/examples/utoo-pack/src/index.tsx
+++ b/examples/utoo-pack/src/index.tsx
@@ -11,6 +11,8 @@ import { a } from '@/a';
 console.log(a);
 // console.log(a1);
 
+console.log(require('alias-module'));
+
 function App({ content }: { content: string }) {
   // @ts-ignore
   return <div>{content}</div>;

--- a/examples/utoo-pack/src/reset.css
+++ b/examples/utoo-pack/src/reset.css
@@ -1,0 +1,3 @@
+div {
+  background-color: red;
+}

--- a/src/builder/bundle/index.ts
+++ b/src/builder/bundle/index.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { getCachePath, logger } from '../../utils';
 import type { BundleConfigProvider } from '../config';
 import {
+  convertCopyConfig,
   convertExternalsToUtooPackExternals,
   getBabelPresetReactOpts,
   getBabelStyledComponentsOpts,
@@ -196,7 +197,9 @@ async function bundle(opts: IBundleOpts): Promise<void | IBundleWatcher> {
       };
       if (config.bundler === 'utoopack') {
         const entryName = path.parse(config.output.filename).name;
+        const distPath = config.output.path;
         const externals = convertExternalsToUtooPackExternals(config.externals);
+        const copy = convertCopyConfig(config.copy, distPath);
         const utooPackOpts: BundleOptions = {
           config: {
             entry: [
@@ -221,8 +224,9 @@ async function bundle(opts: IBundleOpts): Promise<void | IBundleWatcher> {
               inlineCss: {},
             },
             output: {
-              path: config.output.path,
+              path: distPath,
               filename: config.output.filename,
+              copy,
             },
             optimization: {
               minify: config.jsMinifier !== JSMinifier.none,

--- a/src/builder/utils.ts
+++ b/src/builder/utils.ts
@@ -1,4 +1,7 @@
-import type { IConfig as IBundlerWebpackConfig } from '@umijs/bundler-webpack/dist/types';
+import type {
+  IConfig as IBundlerWebpackConfig,
+  ICopy,
+} from '@umijs/bundler-webpack/dist/types';
 import { semver } from '@umijs/utils';
 import type { ExternalConfig } from '@utoo/pack/cjs/types';
 import { createHash } from 'crypto';
@@ -252,4 +255,29 @@ export function convertExternalsToUtooPackExternals(
   // Function and RegExp externals are not supported in utoopack
   // Return empty object to avoid errors
   return {};
+}
+
+export function convertCopyConfig(
+  copy?: IBundlerWebpackConfig['copy'],
+  distPath?: string,
+): Array<ICopy> {
+  if (!copy) {
+    return [];
+  }
+
+  return [
+    ...copy.map((pattern) => {
+      if (typeof pattern === 'string') {
+        return {
+          from: pattern,
+          to: distPath ?? '',
+        };
+      } else {
+        return {
+          from: pattern.from,
+          to: pattern.to,
+        };
+      }
+    }),
+  ];
 }

--- a/src/features/configPlugins/schema.ts
+++ b/src/features/configPlugins/schema.ts
@@ -74,6 +74,9 @@ export function getSchemas(): Record<string, (Joi: Root) => any> {
         theme: Joi.object().pattern(Joi.string(), Joi.string()),
         bundler: Joi.string().optional(),
         rootPath: Joi.string().optional(),
+        copy: Joi.array()
+          .items(Joi.object().pattern(Joi.string(), Joi.string()))
+          .optional(),
       }),
     prebundle: (Joi) =>
       Joi.object({

--- a/src/types.ts
+++ b/src/types.ts
@@ -262,6 +262,11 @@ export interface IFatherBundleConfig extends IFatherBaseConfig {
    * @note When set to true, unminified js file will be generated in the same directory without sourcemap.
    */
   generateUnminified?: boolean;
+
+  /**
+   * copy
+   */
+  copy?: IBundlerWebpackConfig['copy'];
 }
 
 export interface IFatherPreBundleConfig {


### PR DESCRIPTION
支持 `config.copy` 配置，目前先暂时只支持 `utoopack` 场景:

```ts
export default defineConfig({
   umd: {
     copy: [
        {
          from: './src/reset.css',
          to: './reset.css',
        },
     ]
   },
});
```