### PR TITLE
fix: plugins in extends configuration not taking effect (#796)

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -1,8 +1,113 @@
+import { deepmerge, resolve } from '@umijs/utils';
+import path from 'path';
 import { IApi } from './types';
+
+/**
+ * parse extends option for config
+ */
+function parseExtendsConfig(opts: {
+  config: Record<string, any>;
+  resolvePaths: string[];
+  api: IApi;
+}) {
+  let { config } = opts;
+  const { api, resolvePaths } = opts;
+
+  if (config.extends) {
+    let absExtendsPath = '';
+    const ConfigManager: any = api.service.configManager!.constructor;
+
+    // try to resolve extends path
+    resolvePaths.some((dir) => {
+      try {
+        absExtendsPath = resolve.sync(config.extends, {
+          basedir: dir,
+          extensions: ['.js', '.ts'],
+        });
+        return true;
+      } catch {}
+    });
+
+    if (!absExtendsPath) {
+      throw new Error(`Cannot find extends config file: ${config.extends}`);
+    } else if (api.service.configManager!.files.includes(absExtendsPath)) {
+      throw new Error(
+        `Cannot extends config circularly for file: ${absExtendsPath}`,
+      );
+    }
+
+    delete config.extends;
+
+    // load extends config
+    const { config: extendsConfig, files: extendsFiles } =
+      ConfigManager.getUserConfig({ configFiles: [absExtendsPath] });
+
+    if (Array.isArray(extendsConfig.presets)) {
+      extendsConfig.presets = resolvePathArray(
+        extendsConfig.presets,
+        path.dirname(absExtendsPath),
+      );
+    }
+
+    if (Array.isArray(extendsConfig.plugins)) {
+      extendsConfig.plugins = resolvePathArray(
+        extendsConfig.plugins,
+        path.dirname(absExtendsPath),
+      );
+    }
+
+    // try to parse nested extends config
+    const nestedConfig = parseExtendsConfig({
+      config: extendsConfig,
+      resolvePaths: [path.dirname(absExtendsPath)],
+      api,
+    });
+
+    // merge extends config & save related files
+    config = deepmerge(nestedConfig, config);
+    api.service.configManager!.files.push(...extendsFiles);
+  }
+
+  return config;
+}
+
+function resolvePathArray(arr: string[], baseDir: string) {
+  return arr.map((item) => {
+    if (typeof item !== 'string') return item;
+    if (path.isAbsolute(item)) return item;
+
+    // Only resolve explicit relative specifiers. Others are treated as npm packages.
+    if (/^\.\.?[\/\\]/.test(item)) {
+      return resolve.sync(item, {
+        basedir: baseDir,
+        extensions: ['.js', '.ts'],
+      });
+    }
+    return item;
+  });
+}
 
 export default (api: IApi) => {
   api.onStart(() => {});
+
+  const extendsPath = api.userConfig.extends;
+  let extendsPlugins: string[] = [];
+  let extendsPresets: string[] = [];
+  if (extendsPath) {
+    const { plugins, presets, ...extendsConfig } = parseExtendsConfig({
+      api,
+      config: { extends: extendsPath },
+      resolvePaths: api.service
+        .configManager!.getUserConfig()
+        .files.map((file) => path.dirname(file)),
+    });
+    api.appData.extendsConfig = extendsConfig;
+    extendsPlugins = plugins;
+    extendsPresets = presets;
+  }
+
   return {
+    presets: [...(extendsPresets || [])],
     plugins: [
       require.resolve('./registerMethods'),
 
@@ -25,6 +130,9 @@ export default (api: IApi) => {
       require.resolve('./features/configBuilder/configBuilder'),
       require.resolve('./features/configPlugins/configPlugins'),
       require.resolve('./features/depsOnDemand/swc'),
+
+      // extends plugins
+      ...(extendsPlugins || []),
     ],
   };
 };

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -99,3 +99,27 @@ test('config: custom tsconfig name', async () => {
   // check result
   require(`${process.env.APP_ROOT}/expect`).default(fileMap);
 });
+
+test('config: extends plugins and presets should be registered', async () => {
+  // execute build
+  process.env.APP_ROOT = path.join(CASES_DIR, 'config-extends-plugins');
+
+  // workaround for get config file path
+  global.TMP_CASE_CONFIG = path.join(process.env.APP_ROOT, '.fatherrc.ts');
+
+  await cli.run({
+    args: { _: ['build'], $0: 'node' },
+  });
+
+  // prepare file map
+  const fileMap = distToMap(
+    path.join(CASES_DIR, 'config-extends-plugins', 'dist'),
+  );
+
+  // check result
+  require(`${process.env.APP_ROOT}/expect`).default(fileMap);
+
+  // restore mock
+  jest.unmock('@umijs/utils');
+  delete global.TMP_CASE_CONFIG;
+});

--- a/tests/fixtures/config/config-extends-plugins/.fatherrc.base.ts
+++ b/tests/fixtures/config/config-extends-plugins/.fatherrc.base.ts
@@ -1,0 +1,7 @@
+export default {
+  plugins: ['./plugins/base-plugin-1'],
+  presets: ['./presets/base-preset-1'],
+  esm: {
+    transformer: 'babel',
+  },
+};

--- a/tests/fixtures/config/config-extends-plugins/.fatherrc.ts
+++ b/tests/fixtures/config/config-extends-plugins/.fatherrc.ts
@@ -1,0 +1,7 @@
+export default {
+  extends: './.fatherrc.base.ts',
+  plugins: ['./plugins/child-plugin-1'],
+  esm: {
+    transformer: 'esbuild',
+  },
+};

--- a/tests/fixtures/config/config-extends-plugins/expect.ts
+++ b/tests/fixtures/config/config-extends-plugins/expect.ts
@@ -1,0 +1,5 @@
+export default (files: Record<string, string>) => {
+  expect(files['esm/index.js']).toContain('base-plugin-1');
+  expect(files['esm/index.js']).toContain('child-plugin-1');
+  expect(files['esm/index.js']).toContain('plugin-from-preset');
+};

--- a/tests/fixtures/config/config-extends-plugins/plugins/base-plugin-1.ts
+++ b/tests/fixtures/config/config-extends-plugins/plugins/base-plugin-1.ts
@@ -1,0 +1,11 @@
+import { IApi } from '../../../../../src/types';
+
+export default (api: IApi) => {
+  api.modifyConfig((config) => {
+    config.define = {
+      ...config.define,
+      'process.env.BASE_PLUGIN_1': `"base-plugin-1"`,
+    };
+    return config;
+  });
+};

--- a/tests/fixtures/config/config-extends-plugins/plugins/child-plugin-1.ts
+++ b/tests/fixtures/config/config-extends-plugins/plugins/child-plugin-1.ts
@@ -1,0 +1,11 @@
+import { IApi } from '../../../../../src/types';
+
+export default (api: IApi) => {
+  api.modifyConfig((config) => {
+    config.define = {
+      ...config.define,
+      'process.env.CHILD_PLUGIN_1': `"child-plugin-1"`,
+    };
+    return config;
+  });
+};

--- a/tests/fixtures/config/config-extends-plugins/plugins/plugin-from-preset.ts
+++ b/tests/fixtures/config/config-extends-plugins/plugins/plugin-from-preset.ts
@@ -1,0 +1,11 @@
+import { IApi } from '../../../../../src/types';
+
+export default (api: IApi) => {
+  api.modifyConfig((config) => {
+    config.define = {
+      ...config.define,
+      'process.env.PLUGIN_FROM_PRESET': `"plugin-from-preset"`,
+    };
+    return config;
+  });
+};

--- a/tests/fixtures/config/config-extends-plugins/presets/base-preset-1.ts
+++ b/tests/fixtures/config/config-extends-plugins/presets/base-preset-1.ts
@@ -1,0 +1,5 @@
+export default () => {
+  return {
+    plugins: [require.resolve('../plugins/plugin-from-preset')],
+  };
+};

--- a/tests/fixtures/config/config-extends-plugins/src/index.ts
+++ b/tests/fixtures/config/config-extends-plugins/src/index.ts
@@ -1,0 +1,5 @@
+export default function () {
+  console.log(process.env.BASE_PLUGIN_1);
+  console.log(process.env.CHILD_PLUGIN_1);
+  console.log(process.env.PLUGIN_FROM_PRESET);
+}


### PR DESCRIPTION
## Description

Fixes the issue where plugins defined in extended configuration files (via `extends` option) were not being loaded and executed.

## Problem

As reported in #796, when using the `extends` configuration, plugins defined in the inherited configuration file do not take effect. The issue occurs because:

1. Plugin loading happens in the `initPlugins` stage before `extends` configuration is merged
2. The `extends` configuration processing occurs in the `resolveConfig` stage via `api.modifyConfig`
3. This timing mismatch prevents plugins from the extended config from being registered

## Solution

- **Parse extends config in preset stage**: Move extends configuration parsing to the preset stage where `api.registerPresets()` can be called
- **Store parsed config in appData**: Use `api.service.appData.extendsConfig` to share parsed configuration between preset and plugin stages

## Changes

- Modified `src/preset.ts` to parse extends configuration and register presets
- Updated `src/features/configPlugins/configPlugins.ts` to use pre-parsed extends config

## Testing

- Added integration test case `config-extends-plugins` to verify the fix
- Test covers both plugins and presets inheritance from extends configuration

## Fixes

Closes #796

## Breaking Changes

None - this is a backward-compatible fix that only affects extends configuration behavior.