### PR TITLE
fix(utoopack): set assetModuleFilename align with webpack

### DIFF
--- a/src/builder/bundle/index.ts
+++ b/src/builder/bundle/index.ts
@@ -274,6 +274,7 @@ async function bundle(opts: IBundleOpts): Promise<void | IBundleWatcher> {
               path: distPath,
               filename: config.output.filename,
               cssFilename: '[name].css',
+              assetModuleFilename: 'static/[name].[contenthash:8]',
               copy,
             },
             optimization: {


### PR DESCRIPTION
Align with father's `bundler-utoopack`: https://github.com/umijs/umi/blob/master/packages/bundler-webpack/src/config/config.ts#L88