### PR TITLE
ci: update node version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,18 +25,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: [14.x, 16.x, 18.x]
+        node_version: [20.x, 22.x, 24.x]
         os: [ubuntu-latest, windows-latest]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - name: Use Node.js ${{ matrix.node_version }}
+        uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.node_version }}
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Install pnpm
@@ -49,13 +49,13 @@ jobs:
         run: |
           echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-store-node${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-store-node${{ matrix.node_version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-node${{ matrix.node-version }}-
+            ${{ runner.os }}-pnpm-store-node${{ matrix.node_version }}-
 
       - name: Install dependencies
         run: pnpm i
@@ -67,14 +67,14 @@ jobs:
         run: pnpm tsc --noEmit
 
       - name: Run tests
-        if: matrix.node_version != '18.x' || matrix.os != 'ubuntu-latest'
+        if: matrix.node_version != '24.x' || matrix.os != 'ubuntu-latest'
         run: pnpm test
         env:
           CI: true
           NODE_ENV: test
 
       - name: Run tests & report coverage
-        if: matrix.node_version == '18.x' && matrix.os == 'ubuntu-latest'
+        if: matrix.node_version == '24.x' && matrix.os == 'ubuntu-latest'
         run: |
           pnpm test:cov
           bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
## Summary

- update the CI Node.js matrix from 14/16/18 to 20/22/24
- move coverage reporting from Node 18 on Ubuntu to Node 24 on Ubuntu
- update checkout/setup-node/cache actions to v4
- fix matrix references from `matrix.node-version` to `matrix.node_version`

## Validation

- `git diff --check`

This is a workflow-only change, so the main validation is the GitHub Actions run for this PR.