### PR TITLE
fix: handle extensionless tsgo bin entry

### DIFF
--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -99,8 +99,15 @@ export function resolveTsgoBin(cwd: string) {
       : typeof pkg.bin?.tsgo === 'string'
       ? pkg.bin.tsgo
       : undefined;
+  const declaredBinHasExtension = declaredBin
+    ? Boolean(path.extname(declaredBin))
+    : false;
   const candidates = [
-    declaredBin,
+    declaredBinHasExtension ? declaredBin : undefined,
+    // @typescript/native-preview >= 7.0.0-dev.20260629.1 uses an extensionless
+    // bin shim, which Node 16 cannot load inside a "type": "module" package.
+    'lib/tsgo.js',
+    declaredBinHasExtension ? undefined : declaredBin,
     // @typescript/native-preview <= 7.0.0-dev.20260624.1
     'bin/tsgo.js',
     // @typescript/native-preview >= 7.0.0-dev.20260629.1

--- a/tests/tsgo.test.ts
+++ b/tests/tsgo.test.ts
@@ -36,6 +36,7 @@ afterAll(() => {
 function createNativePreviewFixture(
   pkgJson: Record<string, any>,
   binPath: string,
+  extraFiles: string[] = [],
 ) {
   const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'father-tsgo-'));
   tmpDirs.push(cwd);
@@ -48,6 +49,10 @@ function createNativePreviewFixture(
   );
   const fullBinPath = path.join(pkgDir, binPath);
   fs.mkdirSync(path.dirname(fullBinPath), { recursive: true });
+  extraFiles.forEach((file) => {
+    fs.mkdirSync(path.dirname(path.join(pkgDir, file)), { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, file), '#!/usr/bin/env node\n');
+  });
   fs.writeFileSync(
     path.join(pkgDir, 'package.json'),
     JSON.stringify({ name: '@typescript/native-preview', ...pkgJson }),
@@ -57,10 +62,10 @@ function createNativePreviewFixture(
   return { cwd, binPath };
 }
 
-test('resolve tsgo bin from package bin field', () => {
+test('resolve tsgo bin from package bin field with file extension', () => {
   const fixture = createNativePreviewFixture(
-    { bin: { tsgo: 'bin/tsgo' } },
-    'bin/tsgo',
+    { bin: { tsgo: 'bin/tsgo.js' } },
+    'bin/tsgo.js',
   );
 
   const resolvedBin = resolveTsgoBin(fixture.cwd);
@@ -68,6 +73,21 @@ test('resolve tsgo bin from package bin field', () => {
   expect(fs.existsSync(resolvedBin)).toBe(true);
   expect(
     path.normalize(resolvedBin).endsWith(path.normalize(fixture.binPath)),
+  ).toBe(true);
+});
+
+test('resolve tsgo js entry when package bin field is extensionless', () => {
+  const fixture = createNativePreviewFixture(
+    { bin: { tsgo: 'bin/tsgo' } },
+    'bin/tsgo',
+    ['lib/tsgo.js'],
+  );
+
+  const resolvedBin = resolveTsgoBin(fixture.cwd);
+
+  expect(fs.existsSync(resolvedBin)).toBe(true);
+  expect(
+    path.normalize(resolvedBin).endsWith(path.normalize('lib/tsgo.js')),
   ).toBe(true);
 });
 


### PR DESCRIPTION
## What changed

- Resolve extensionless `@typescript/native-preview` `bin/tsgo` entries to `lib/tsgo.js` before falling back to the shim.
- Keep package-declared bins with file extensions, such as the older `bin/tsgo.js`, as the preferred path.
- Add tests for both extensioned and extensionless tsgo bin layouts.

## Why

`@typescript/native-preview` latest versions publish `bin.tsgo` as `./bin/tsgo`, an extensionless ESM shim. father currently executes the resolved bin via `node <bin>`. Under Node 16, loading that extensionless file inside a `type: module` package fails with `ERR_UNKNOWN_FILE_EXTENSION`.

Using `lib/tsgo.js` for the extensionless layout preserves Node-based execution while avoiding the extensionless ESM loader failure.

## Validation

- `./node_modules/.bin/jest tests/tsgo.test.ts --runInBand`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/prettier --check src/builder/bundless/dts/index.ts tests/tsgo.test.ts`
- Verified `/Users/zoomdong/hologram-module` with the patched local father dist: `tnpm run build`
