### PR TITLE
feat: support TypeScript 7 native compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /tests/fixtures/**/dist
 /tests/fixtures/deps/*/node_modules
 /tests/fixtures/dev/node_modules
+/tests/fixtures/tsgo-dts/node_modules
 /tests/fixtures/build/*/node_modules
 /tests/fixtures/prebundle/*/compiled
 /tests/fixtures/prebundle/*/modules

--- a/docs/config.en-US.md
+++ b/docs/config.en-US.md
@@ -27,27 +27,21 @@ Father supports the following configuration options.
 
 - **Type**: `{ compiler?: "tsc" | "tsgo" }`
 - **Default**: `{ compiler: "tsc" }`
-- Configures TypeScript declaration generation. Father uses the built-in TypeScript Compiler API by default. Set `compiler` to `"tsgo"` to generate `.d.ts` files with [tsgo](https://github.com/microsoft/typescript-go).
+- Configures TypeScript declaration generation. Father uses the built-in TypeScript Compiler API by default. Set `compiler` to `"tsgo"` to generate `.d.ts` files with the TypeScript 7 native compiler or the legacy tsgo preview.
 
-#### **Using tsgo**
+#### **Using the native TypeScript compiler**
 
-Setting `compiler` to `"tsgo"` uses [tsgo](https://github.com/microsoft/typescript-go) to generate declaration files. It keeps type checking while improving declaration generation performance.
+Setting `compiler` to `"tsgo"` uses the [TypeScript 7 native compiler](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/) to generate declaration files. It keeps type checking while improving declaration generation performance. The `tsgo` configuration name is preserved for compatibility with projects that already enabled this mode.
 
-1. Install `@typescript/native-preview` as a development dependency:
+1. Install TypeScript 7 as a development dependency:
 
 ```bash
-pnpm add @typescript/native-preview -D
-# or
-npm add @typescript/native-preview -D
-# or
-yarn add @typescript/native-preview -D
-# or
-bun add @typescript/native-preview -d
+pnpm add typescript@^7 -D
 ```
 
-> `@typescript/native-preview` requires Node.js 20.6.0 or higher.
+> TypeScript 7 requires Node.js 16.20.0 or higher. Father also continues to recognize `@typescript/native-preview` for projects that have not migrated yet.
 
-2. Enable `tsgo` in the father config:
+2. Enable native declaration generation in the Father config:
 
 ```ts
 export default {
@@ -59,15 +53,7 @@ export default {
 };
 ```
 
-3. To keep the local development experience consistent, install the [VS Code Preview Extension](https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview) and enable it in VS Code settings:
-
-```json
-{
-  "typescript.experimental.useTsgo": true
-}
-```
-
-> **Note**: `tsgo` is experimental and requires `@typescript/native-preview` to be installed in your project. Father's built-in `typescript` dependency is the JavaScript TypeScript Compiler API, while `tsgo` is provided by a separate native preview package and is not part of the `typescript` package. To avoid installing an experimental native binary for every user by default, father only checks for this dependency when `compiler: 'tsgo'` is enabled.
+> **Note**: Father prefers `typescript@7` and falls back to `@typescript/native-preview`. To avoid installing native binaries for every user, Father only checks these dependencies when `compiler: 'tsgo'` is enabled.
 
 ### **extraBabelPlugins**
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -42,27 +42,21 @@ FATHER_TSCONFIG_NAME=tsconfig.build.json father build
 - 类型：`{ compiler?: 'tsc' | 'tsgo' }`
 - 默认值：`{ compiler: 'tsc' }`
 
-配置 TypeScript 类型声明生成方式。默认使用 father 内置的 TypeScript Compiler API；当配置为 `compiler: 'tsgo'` 时，会使用 [tsgo](https://github.com/microsoft/typescript-go) 生成 `.d.ts` 文件。
+配置 TypeScript 类型声明生成方式。默认使用 father 内置的 TypeScript Compiler API；当配置为 `compiler: 'tsgo'` 时，会使用 TypeScript 7 原生编译器（或旧版 tsgo preview）生成 `.d.ts` 文件。
 
-#### 使用 tsgo
+#### 使用原生 TypeScript 编译器
 
-开启 `compiler: 'tsgo'` 会使用 [tsgo](https://github.com/microsoft/typescript-go) 生成类型声明文件，在保留类型检查的同时，可以显著加快类型生成速度。
+开启 `compiler: 'tsgo'` 会使用 [TypeScript 7 原生编译器](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/) 生成类型声明文件，在保留类型检查的同时，可以显著加快类型生成速度。配置名 `tsgo` 会继续保留，以兼容已经启用该能力的项目。
 
-1. 安装 `@typescript/native-preview` 作为开发依赖：
+1. 安装 TypeScript 7 作为开发依赖：
 
 ```bash
-pnpm add @typescript/native-preview -D
-# or
-npm add @typescript/native-preview -D
-# or
-yarn add @typescript/native-preview -D
-# or
-bun add @typescript/native-preview -d
+pnpm add typescript@^7 -D
 ```
 
-> `@typescript/native-preview` 要求 Node.js 20.6.0 或更高版本。
+> TypeScript 7 要求 Node.js 16.20.0 或更高版本。father 也会继续识别 `@typescript/native-preview`，以兼容尚未迁移的项目。
 
-2. 在 father 配置中启用 `tsgo`：
+2. 在 father 配置中启用原生声明生成：
 
 ```ts
 export default {
@@ -74,15 +68,7 @@ export default {
 };
 ```
 
-3. 为了保证本地开发体验一致，建议安装 [VS Code Preview Extension](https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview)，并在 VS Code 设置中开启：
-
-```json
-{
-  "typescript.experimental.useTsgo": true
-}
-```
-
-> 注：`tsgo` 目前为实验能力，需要在项目中额外安装 `@typescript/native-preview`。father 内置的 `typescript` 是 JavaScript 版 TypeScript Compiler API，而 `tsgo` 来自单独的原生预览包，并不是 `typescript` 包的一部分。为避免所有用户默认安装实验性的 native binary，father 只会在启用 `compiler: 'tsgo'` 时检查该依赖是否存在。
+> 注：father 会优先识别项目中的 `typescript@7`，并回退兼容 `@typescript/native-preview`。为避免所有用户默认安装原生二进制，father 只会在启用 `compiler: 'tsgo'` 时检查这些依赖。
 
 ### extraBabelPlugins
 

--- a/examples/normal/package.json
+++ b/examples/normal/package.json
@@ -13,6 +13,6 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@typescript/native-preview": "7.0.0-dev.20260609.1"
+    "typescript": "^7.0.2"
   }
 }

--- a/examples/utoo-pack/package.json
+++ b/examples/utoo-pack/package.json
@@ -13,6 +13,6 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@typescript/native-preview": "7.0.0-dev.20260609.1"
+    "typescript": "^7.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,9 +157,9 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
     devDependencies:
-      '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260609.1
-        version: 7.0.0-dev.20260609.1
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
 
   examples/prebundle:
     devDependencies:
@@ -188,9 +188,9 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
     devDependencies:
-      '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260609.1
-        version: 7.0.0-dev.20260609.1
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
 
   tests/fixtures/build/automatic-jsx:
     dependencies:
@@ -216,6 +216,12 @@ importers:
       stylis:
         specifier: ^4.1.3
         version: 4.1.3
+
+  tests/fixtures/tsgo-dts:
+    devDependencies:
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
 
 packages:
 
@@ -3882,8 +3888,17 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.0
 
-  /@typescript/native-preview-darwin-arm64@7.0.0-dev.20260609.1:
-    resolution: {integrity: sha512-Yf/zHEadP/yUiWUdM/mZVfEVFJuGMf6nhRSFif0vp+FwtfGU4jmlpNF7BTJJdOHrrcWkwEJKzAoMCtEtyxhuyQ==}
+  /@typescript/typescript-aix-ppc64@7.0.2:
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/typescript-darwin-arm64@7.0.2:
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
@@ -3891,8 +3906,8 @@ packages:
     dev: true
     optional: true
 
-  /@typescript/native-preview-darwin-x64@7.0.0-dev.20260609.1:
-    resolution: {integrity: sha512-z4dYWI57CPHs0wV/FWFth8fWmqYH7iOm7THOfZ5Fv0jo/SWK6kE1kEUIqIAExqo7ueRNqSrCw0I8U1J4TJszAw==}
+  /@typescript/typescript-darwin-x64@7.0.2:
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
@@ -3900,8 +3915,26 @@ packages:
     dev: true
     optional: true
 
-  /@typescript/native-preview-linux-arm64@7.0.0-dev.20260609.1:
-    resolution: {integrity: sha512-OxNVWH9IhrMAzNlDyDit1dPO64GFIDPOUKoruIkJ9A1ZEONfIHXG5f+V3si9jtuNmuomiz9FjpbzOqLsgaxt+w==}
+  /@typescript/typescript-freebsd-arm64@7.0.2:
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/typescript-freebsd-x64@7.0.2:
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/typescript-linux-arm64@7.0.2:
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
@@ -3909,8 +3942,8 @@ packages:
     dev: true
     optional: true
 
-  /@typescript/native-preview-linux-arm@7.0.0-dev.20260609.1:
-    resolution: {integrity: sha512-mEtN8BbAgVtBu/5MVomYquXNvgok2C0KG6V0D4SV1jfBJNtlcqbp0WuIqT0bnM9DA4TgzcHvnFMpwGSK/dqI5A==}
+  /@typescript/typescript-linux-arm@7.0.2:
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
@@ -3918,8 +3951,53 @@ packages:
     dev: true
     optional: true
 
-  /@typescript/native-preview-linux-x64@7.0.0-dev.20260609.1:
-    resolution: {integrity: sha512-KO8WO1gBIC09T3255RlTY42TGu8en5mEkLPQu2wkMn+dX2T8KYL64zXrCeLeUWa0NvmVdJUeyWu3pFOn3zKemw==}
+  /@typescript/typescript-linux-loong64@7.0.2:
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/typescript-linux-mips64el@7.0.2:
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/typescript-linux-ppc64@7.0.2:
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/typescript-linux-riscv64@7.0.2:
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/typescript-linux-s390x@7.0.2:
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/typescript-linux-x64@7.0.2:
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
@@ -3927,8 +4005,53 @@ packages:
     dev: true
     optional: true
 
-  /@typescript/native-preview-win32-arm64@7.0.0-dev.20260609.1:
-    resolution: {integrity: sha512-+8q19LWjnMKK6SF3PLeMEalbfWDYWHs0AU8kSFCBCke/RLoDG4FjQzVtLgUo+KWhsmZMosiEyqEnZmSlED2tIQ==}
+  /@typescript/typescript-netbsd-arm64@7.0.2:
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/typescript-netbsd-x64@7.0.2:
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/typescript-openbsd-arm64@7.0.2:
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/typescript-openbsd-x64@7.0.2:
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/typescript-sunos-x64@7.0.2:
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/typescript-win32-arm64@7.0.2:
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
@@ -3936,28 +4059,14 @@ packages:
     dev: true
     optional: true
 
-  /@typescript/native-preview-win32-x64@7.0.0-dev.20260609.1:
-    resolution: {integrity: sha512-qNPcss+6yRoNFfFIKQbPwJWYxDfOZwyL8JBJh4J+yMLOad/+/AOjsO4EtZsIpv5PMCjpnD75coBoDkw+5NkItw==}
+  /@typescript/typescript-win32-x64@7.0.2:
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
-
-  /@typescript/native-preview@7.0.0-dev.20260609.1:
-    resolution: {integrity: sha512-1HOuH/u/451O3hx4Z9fesNqarpeit6UfkgwK96sCVWi5p69F0N3v+6bI969lLIjF7K9dbYQNiWUaZ6Wik87iKg==}
-    engines: {node: '>=16.20.0'}
-    hasBin: true
-    optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260609.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260609.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260609.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260609.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260609.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260609.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260609.1
-    dev: true
 
   /@umijs/babel-preset-umi@4.6.73:
     resolution: {integrity: sha512-kIE0ZiusiR0rCVCaxsRGJebQLrdJ520G3lR9mv4eJCxlz9qsr7TP+K2fDi7knQ+zbnJQTXGIzLMx7PJ7+SRWhg==}
@@ -10248,6 +10357,33 @@ packages:
     resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  /typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
+    dev: true
 
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ packages:
   - 'tests/fixtures/build/classic-jsx'
   - 'tests/fixtures/build/automatic-jsx'
   - 'tests/fixtures/build/styled-components'
+  - 'tests/fixtures/tsgo-dts'

--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -1,4 +1,4 @@
-import { chalk, fsExtra, winPath } from '@umijs/utils';
+import { chalk, fsExtra, semver, winPath } from '@umijs/utils';
 import { execFile } from 'child_process';
 import fs from 'fs';
 import path from 'path';
@@ -79,52 +79,69 @@ function getTransformPaths(tsconfig: NonNullable<ParsedTsconfig>, cwd: string) {
 }
 
 export function resolveTsgoBin(cwd: string) {
-  let pkgPath: string;
+  const compilerPackages = [
+    { name: 'typescript', binName: 'tsc', minimumMajor: 7 },
+    { name: '@typescript/native-preview', binName: 'tsgo' },
+  ];
+  const triedPaths: string[] = [];
 
-  try {
-    pkgPath = require.resolve('@typescript/native-preview/package.json', {
-      paths: [cwd],
-    });
-  } catch {
-    throw new Error(
-      'dts.compiler: "tsgo" requires @typescript/native-preview to be installed. Please add it to devDependencies first.',
+  for (const compilerPackage of compilerPackages) {
+    let pkgPath: string;
+
+    try {
+      pkgPath = require.resolve(`${compilerPackage.name}/package.json`, {
+        paths: [cwd],
+      });
+    } catch {
+      continue;
+    }
+
+    const pkgDir = path.dirname(pkgPath);
+    const pkg = fsExtra.readJSONSync(pkgPath);
+
+    if (
+      compilerPackage.minimumMajor &&
+      (!pkg.version || semver.major(pkg.version) < compilerPackage.minimumMajor)
+    ) {
+      continue;
+    }
+
+    const declaredBin =
+      typeof pkg.bin === 'string'
+        ? pkg.bin
+        : typeof pkg.bin?.[compilerPackage.binName] === 'string'
+        ? pkg.bin[compilerPackage.binName]
+        : undefined;
+    const declaredBinHasExtension = declaredBin
+      ? Boolean(path.extname(declaredBin))
+      : false;
+    const candidates = Array.from(
+      new Set(
+        [
+          declaredBinHasExtension ? declaredBin : undefined,
+          // Prefer a JavaScript entry for extensionless ESM bin shims so that
+          // process.execPath can execute it consistently on Node 16 and Windows.
+          `lib/${compilerPackage.binName}.js`,
+          declaredBinHasExtension ? undefined : declaredBin,
+          `bin/${compilerPackage.binName}.js`,
+          `bin/${compilerPackage.binName}`,
+        ].filter(Boolean) as string[],
+      ),
     );
-  }
 
-  const pkgDir = path.dirname(pkgPath);
-  const pkg = fsExtra.readJSONSync(pkgPath);
-  const declaredBin =
-    typeof pkg.bin === 'string'
-      ? pkg.bin
-      : typeof pkg.bin?.tsgo === 'string'
-      ? pkg.bin.tsgo
-      : undefined;
-  const declaredBinHasExtension = declaredBin
-    ? Boolean(path.extname(declaredBin))
-    : false;
-  const candidates = [
-    declaredBinHasExtension ? declaredBin : undefined,
-    // @typescript/native-preview >= 7.0.0-dev.20260629.1 uses an extensionless
-    // bin shim, which Node 16 cannot load inside a "type": "module" package.
-    'lib/tsgo.js',
-    declaredBinHasExtension ? undefined : declaredBin,
-    // @typescript/native-preview <= 7.0.0-dev.20260624.1
-    'bin/tsgo.js',
-    // @typescript/native-preview >= 7.0.0-dev.20260629.1
-    'bin/tsgo',
-  ].filter(Boolean) as string[];
+    for (const candidate of candidates) {
+      const binPath = path.resolve(pkgDir, candidate);
+      triedPaths.push(binPath);
 
-  for (const candidate of candidates) {
-    const binPath = path.resolve(pkgDir, candidate);
-    if (fs.existsSync(binPath)) {
-      return binPath;
+      if (fs.existsSync(binPath)) {
+        return binPath;
+      }
     }
   }
 
   throw new Error(
-    `Cannot find tsgo binary from @typescript/native-preview at ${pkgDir}. Tried: ${candidates
-      .map((candidate) => path.resolve(pkgDir, candidate))
-      .join(', ')}.`,
+    'dts.compiler: "tsgo" requires `typescript@^7` or `@typescript/native-preview`.' +
+      (triedPaths.length ? ` Tried: ${triedPaths.join(', ')}.` : ''),
   );
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,7 +110,7 @@ export interface IFatherDtsConfig {
   /**
    * declaration compiler
    * @default tsc
-   * @experimental tsgo requires @typescript/native-preview to be installed
+   * @experimental tsgo requires TypeScript 7 or @typescript/native-preview
    */
   compiler?: `${IFatherDtsCompilerTypes}`;
 }

--- a/tests/fixtures/tsgo-dts/package.json
+++ b/tests/fixtures/tsgo-dts/package.json
@@ -1,1 +1,6 @@
-{}
+{
+  "private": true,
+  "devDependencies": {
+    "typescript": "^7.0.2"
+  }
+}

--- a/tests/tsgo.test.ts
+++ b/tests/tsgo.test.ts
@@ -9,15 +9,24 @@ import { distToMap } from './utils';
 const CASE_DIR = path.join(__dirname, 'fixtures/tsgo-dts');
 const mockExit = mockProcessExit();
 const tmpDirs: string[] = [];
-const hasTsgo = (() => {
-  try {
-    require.resolve('@typescript/native-preview/package.json', {
-      paths: [CASE_DIR],
-    });
-    return true;
-  } catch {
-    return false;
+const hasNativeTypeScript = (() => {
+  for (const packageName of ['typescript', '@typescript/native-preview']) {
+    try {
+      const pkgPath = require.resolve(`${packageName}/package.json`, {
+        paths: [CASE_DIR],
+      });
+      const pkg = fs.readFileSync(pkgPath, 'utf-8');
+      if (
+        packageName === 'typescript' &&
+        Number(JSON.parse(pkg).version.split('.')[0]) < 7
+      ) {
+        continue;
+      }
+      return true;
+    } catch {}
   }
+
+  return false;
 })();
 
 beforeAll(() => {
@@ -33,20 +42,20 @@ afterAll(() => {
   mockExit.mockRestore();
 });
 
-function createNativePreviewFixture(
+function createCompilerFixture(
+  packageName: string,
   pkgJson: Record<string, any>,
   binPath: string,
   extraFiles: string[] = [],
+  fixtureCwd?: string,
 ) {
-  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'father-tsgo-'));
-  tmpDirs.push(cwd);
+  const cwd =
+    fixtureCwd || fs.mkdtempSync(path.join(os.tmpdir(), 'father-tsgo-'));
+  if (!fixtureCwd) {
+    tmpDirs.push(cwd);
+  }
 
-  const pkgDir = path.join(
-    cwd,
-    'node_modules',
-    '@typescript',
-    'native-preview',
-  );
+  const pkgDir = path.join(cwd, 'node_modules', ...packageName.split('/'));
   const fullBinPath = path.join(pkgDir, binPath);
   fs.mkdirSync(path.dirname(fullBinPath), { recursive: true });
   extraFiles.forEach((file) => {
@@ -55,12 +64,80 @@ function createNativePreviewFixture(
   });
   fs.writeFileSync(
     path.join(pkgDir, 'package.json'),
-    JSON.stringify({ name: '@typescript/native-preview', ...pkgJson }),
+    JSON.stringify({ name: packageName, ...pkgJson }),
   );
   fs.writeFileSync(fullBinPath, '#!/usr/bin/env node\n');
 
   return { cwd, binPath };
 }
+
+function createNativePreviewFixture(
+  pkgJson: Record<string, any>,
+  binPath: string,
+  extraFiles: string[] = [],
+) {
+  return createCompilerFixture(
+    '@typescript/native-preview',
+    pkgJson,
+    binPath,
+    extraFiles,
+  );
+}
+
+test('resolve stable TypeScript 7', () => {
+  const fixture = createCompilerFixture(
+    'typescript',
+    {
+      version: '7.0.2',
+      type: 'module',
+      bin: { tsc: './bin/tsc' },
+    },
+    'bin/tsc',
+    ['lib/tsc.js'],
+  );
+
+  const resolvedBin = resolveTsgoBin(fixture.cwd);
+
+  expect(fs.existsSync(resolvedBin)).toBe(true);
+  expect(
+    path.normalize(resolvedBin).endsWith(path.normalize('lib/tsc.js')),
+  ).toBe(true);
+});
+
+test('ignore the legacy TypeScript package API', () => {
+  const fixture = createCompilerFixture(
+    'typescript',
+    { version: '6.0.3', bin: { tsc: 'bin/tsc' } },
+    'bin/tsc',
+    ['lib/tsc.js'],
+  );
+
+  expect(() => resolveTsgoBin(fixture.cwd)).toThrow('requires `typescript@^7`');
+});
+
+test('fall back to native preview for legacy TypeScript projects', () => {
+  const legacyFixture = createCompilerFixture(
+    'typescript',
+    { version: '6.0.3', bin: { tsc: 'bin/tsc' } },
+    'bin/tsc',
+    ['lib/tsc.js'],
+  );
+  createCompilerFixture(
+    '@typescript/native-preview',
+    { version: '7.0.0-dev.20260629.1', bin: { tsgo: 'bin/tsgo' } },
+    'bin/tsgo',
+    ['lib/tsgo.js'],
+    legacyFixture.cwd,
+  );
+
+  const resolvedBin = resolveTsgoBin(legacyFixture.cwd);
+
+  expect(
+    path
+      .normalize(resolvedBin)
+      .endsWith(path.normalize('@typescript/native-preview/lib/tsgo.js')),
+  ).toBe(true);
+});
 
 test('resolve tsgo bin from package bin field with file extension', () => {
   const fixture = createNativePreviewFixture(
@@ -102,16 +179,19 @@ test('resolve legacy tsgo.js bin when package bin field is unavailable', () => {
   ).toBe(true);
 });
 
-(hasTsgo ? test : test.skip)('build: bundless tsgo dts', async () => {
-  process.env.APP_ROOT = CASE_DIR;
-  await cli.run({
-    args: { _: ['build'], $0: 'node' },
-  });
+(hasNativeTypeScript ? test : test.skip)(
+  'build: bundless native TypeScript dts',
+  async () => {
+    process.env.APP_ROOT = CASE_DIR;
+    await cli.run({
+      args: { _: ['build'], $0: 'node' },
+    });
 
-  const fileMap = distToMap(path.join(CASE_DIR, 'dist'));
+    const fileMap = distToMap(path.join(CASE_DIR, 'dist'));
 
-  expect(fileMap['esm/index.d.ts']).toContain('./value');
-  expect(fileMap['esm/value.d.ts']).toContain(
-    'export declare const value = "tsgo"',
-  );
-});
+    expect(fileMap['esm/index.d.ts']).toContain('./value');
+    expect(fileMap['esm/value.d.ts']).toContain(
+      'export declare const value = "tsgo"',
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- resolve the native compiler from a direct `typescript@7` dependency
- ignore legacy `typescript` versions and keep `@typescript/native-preview` as a compatibility fallback
- prefer JavaScript compiler entries so execution works consistently on Node.js 16 and Windows
- migrate examples, documentation, and the declaration fixture to stable TypeScript 7

## Why

TypeScript 7 now ships its native compiler from the standard `typescript` package. Father previously only resolved the separate preview package, so projects using stable TypeScript 7 could not use `dts.compiler: 'tsgo'` directly.

## Validation

- `pnpm run build`
- focused tsgo suite: 7 tests passed
- full suite: 15 test suites and 143 tests passed (the existing Jest open-handle warning remains after completion)
- `pnpm install --frozen-lockfile --ignore-scripts`
- `git diff --check`
