### PR TITLE
fix: support TypeScript 7 side-by-side alias

### DIFF
--- a/docs/config.en-US.md
+++ b/docs/config.en-US.md
@@ -39,7 +39,7 @@ Setting `compiler` to `"tsgo"` uses the [TypeScript 7 native compiler](https://d
 pnpm add typescript@^7 -D
 ```
 
-If tools in the project still need the TypeScript Compiler API, install TypeScript 7 side-by-side with the TypeScript 6 compatibility package using the aliases recommended by the TypeScript team:
+If tools in the project still need the TypeScript Compiler API, install TypeScript 7 side-by-side with the TypeScript 6 compatibility package using the [aliases recommended by the TypeScript team](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-60):
 
 ```json
 {

--- a/docs/config.en-US.md
+++ b/docs/config.en-US.md
@@ -39,7 +39,7 @@ Setting `compiler` to `"tsgo"` uses the [TypeScript 7 native compiler](https://d
 pnpm add typescript@^7 -D
 ```
 
-If tools in the project still need the TypeScript Compiler API, install TypeScript 7 side-by-side with the TypeScript 6 compatibility package using the [aliases recommended by the TypeScript team](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-60):
+If tools in the project still need the TypeScript Compiler API, install TypeScript 7 side-by-side with the TypeScript 6 compatibility package using the [aliases recommended by the TypeScript team](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0):
 
 ```json
 {

--- a/docs/config.en-US.md
+++ b/docs/config.en-US.md
@@ -39,7 +39,18 @@ Setting `compiler` to `"tsgo"` uses the [TypeScript 7 native compiler](https://d
 pnpm add typescript@^7 -D
 ```
 
-> TypeScript 7 requires Node.js 16.20.0 or higher. Father also continues to recognize `@typescript/native-preview` for projects that have not migrated yet.
+If tools in the project still need the TypeScript Compiler API, install TypeScript 7 side-by-side with the TypeScript 6 compatibility package using the aliases recommended by the TypeScript team:
+
+```json
+{
+  "devDependencies": {
+    "@typescript/native": "npm:typescript@^7.0.2",
+    "typescript": "npm:@typescript/typescript6@^6.0.2"
+  }
+}
+```
+
+> TypeScript 7 requires Node.js 16.20.0 or higher. Father recognizes both a direct `typescript@7` dependency and the official `@typescript/native` alias. It also continues to recognize `@typescript/native-preview` for projects that have not migrated yet.
 
 2. Enable native declaration generation in the Father config:
 
@@ -53,7 +64,7 @@ export default {
 };
 ```
 
-> **Note**: Father prefers `typescript@7` and falls back to `@typescript/native-preview`. To avoid installing native binaries for every user, Father only checks these dependencies when `compiler: 'tsgo'` is enabled.
+> **Note**: Father prefers `typescript@7`, then the `@typescript/native` alias, and finally falls back to `@typescript/native-preview`. To avoid installing native binaries for every user, Father only checks these dependencies when `compiler: 'tsgo'` is enabled.
 
 ### **extraBabelPlugins**
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -54,7 +54,18 @@ FATHER_TSCONFIG_NAME=tsconfig.build.json father build
 pnpm add typescript@^7 -D
 ```
 
-> TypeScript 7 要求 Node.js 16.20.0 或更高版本。father 也会继续识别 `@typescript/native-preview`，以兼容尚未迁移的项目。
+如果项目中的工具仍依赖 TypeScript Compiler API，可以按照 TypeScript 官方推荐的 alias 方案并行安装 TypeScript 7 和 TypeScript 6 兼容包：
+
+```json
+{
+  "devDependencies": {
+    "@typescript/native": "npm:typescript@^7.0.2",
+    "typescript": "npm:@typescript/typescript6@^6.0.2"
+  }
+}
+```
+
+> TypeScript 7 要求 Node.js 16.20.0 或更高版本。father 会识别直接安装的 `typescript@7` 和官方约定的 `@typescript/native` alias，也会继续识别 `@typescript/native-preview`，以兼容尚未迁移的项目。
 
 2. 在 father 配置中启用原生声明生成：
 
@@ -68,7 +79,7 @@ export default {
 };
 ```
 
-> 注：father 会优先识别项目中的 `typescript@7`，并回退兼容 `@typescript/native-preview`。为避免所有用户默认安装原生二进制，father 只会在启用 `compiler: 'tsgo'` 时检查这些依赖。
+> 注：father 会依次识别项目中的 `typescript@7`、`@typescript/native` alias，并回退兼容 `@typescript/native-preview`。为避免所有用户默认安装原生二进制，father 只会在启用 `compiler: 'tsgo'` 时检查这些依赖。
 
 ### extraBabelPlugins
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -54,7 +54,7 @@ FATHER_TSCONFIG_NAME=tsconfig.build.json father build
 pnpm add typescript@^7 -D
 ```
 
-如果项目中的工具仍依赖 TypeScript Compiler API，可以按照 [TypeScript 官方推荐的 alias 方案](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-60)并行安装 TypeScript 7 和 TypeScript 6 兼容包：
+如果项目中的工具仍依赖 TypeScript Compiler API，可以按照 [TypeScript 官方推荐的 alias 方案](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0)并行安装 TypeScript 7 和 TypeScript 6 兼容包：
 
 ```json
 {

--- a/docs/config.md
+++ b/docs/config.md
@@ -54,7 +54,7 @@ FATHER_TSCONFIG_NAME=tsconfig.build.json father build
 pnpm add typescript@^7 -D
 ```
 
-如果项目中的工具仍依赖 TypeScript Compiler API，可以按照 TypeScript 官方推荐的 alias 方案并行安装 TypeScript 7 和 TypeScript 6 兼容包：
+如果项目中的工具仍依赖 TypeScript Compiler API，可以按照 [TypeScript 官方推荐的 alias 方案](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-60)并行安装 TypeScript 7 和 TypeScript 6 兼容包：
 
 ```json
 {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,9 +219,12 @@ importers:
 
   tests/fixtures/tsgo-dts:
     devDependencies:
+      '@typescript/native':
+        specifier: npm:typescript@^7.0.2
+        version: /typescript@7.0.2
       typescript:
-        specifier: ^7.0.2
-        version: 7.0.2
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: /@typescript/typescript6@6.0.2
 
 packages:
 
@@ -4067,6 +4070,13 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@typescript/typescript6@6.0.2:
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
+    hasBin: true
+    dependencies:
+      '@typescript/old': /typescript@6.0.3
+    dev: true
 
   /@umijs/babel-preset-umi@4.6.75:
     resolution: {integrity: sha512-EL3WitQebAws7tbHw3VNCaMwZJUZ5XN7DsCXVHzgCtgscb63YNzhZEQR9LdaY4XAeWQJKSJrVVOvwm/iDWSCBg==}
@@ -10357,6 +10367,12 @@ packages:
     resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  /typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
 
   /typescript@7.0.2:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}

--- a/src/builder/bundless/dts/index.ts
+++ b/src/builder/bundless/dts/index.ts
@@ -81,6 +81,7 @@ function getTransformPaths(tsconfig: NonNullable<ParsedTsconfig>, cwd: string) {
 export function resolveTsgoBin(cwd: string) {
   const compilerPackages = [
     { name: 'typescript', binName: 'tsc', minimumMajor: 7 },
+    { name: '@typescript/native', binName: 'tsc', minimumMajor: 7 },
     { name: '@typescript/native-preview', binName: 'tsgo' },
   ];
   const triedPaths: string[] = [];
@@ -140,7 +141,7 @@ export function resolveTsgoBin(cwd: string) {
   }
 
   throw new Error(
-    'dts.compiler: "tsgo" requires `typescript@^7` or `@typescript/native-preview`.' +
+    'dts.compiler: "tsgo" requires `typescript@^7`, the `@typescript/native` alias, or `@typescript/native-preview`.' +
       (triedPaths.length ? ` Tried: ${triedPaths.join(', ')}.` : ''),
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,7 +110,7 @@ export interface IFatherDtsConfig {
   /**
    * declaration compiler
    * @default tsc
-   * @experimental tsgo requires TypeScript 7 or @typescript/native-preview
+   * @experimental tsgo requires TypeScript 7 (direct or @typescript/native alias) or @typescript/native-preview
    */
   compiler?: `${IFatherDtsCompilerTypes}`;
 }

--- a/tests/fixtures/tsgo-dts/package.json
+++ b/tests/fixtures/tsgo-dts/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "devDependencies": {
-    "typescript": "^7.0.2"
+    "@typescript/native": "npm:typescript@^7.0.2",
+    "typescript": "npm:@typescript/typescript6@^6.0.2"
   }
 }

--- a/tests/tsgo.test.ts
+++ b/tests/tsgo.test.ts
@@ -10,14 +10,18 @@ const CASE_DIR = path.join(__dirname, 'fixtures/tsgo-dts');
 const mockExit = mockProcessExit();
 const tmpDirs: string[] = [];
 const hasNativeTypeScript = (() => {
-  for (const packageName of ['typescript', '@typescript/native-preview']) {
+  for (const packageName of [
+    'typescript',
+    '@typescript/native',
+    '@typescript/native-preview',
+  ]) {
     try {
       const pkgPath = require.resolve(`${packageName}/package.json`, {
         paths: [CASE_DIR],
       });
       const pkg = fs.readFileSync(pkgPath, 'utf-8');
       if (
-        packageName === 'typescript' &&
+        packageName !== '@typescript/native-preview' &&
         Number(JSON.parse(pkg).version.split('.')[0]) < 7
       ) {
         continue;
@@ -71,17 +75,29 @@ function createCompilerFixture(
   return { cwd, binPath };
 }
 
+function createLegacyNativeAliasFixture(cwd: string) {
+  createCompilerFixture(
+    '@typescript/native',
+    { name: 'typescript', version: '6.0.3', bin: { tsc: 'bin/tsc' } },
+    'bin/tsc',
+    [],
+    cwd,
+  );
+}
+
 function createNativePreviewFixture(
   pkgJson: Record<string, any>,
   binPath: string,
   extraFiles: string[] = [],
 ) {
-  return createCompilerFixture(
+  const fixture = createCompilerFixture(
     '@typescript/native-preview',
     pkgJson,
     binPath,
     extraFiles,
   );
+  createLegacyNativeAliasFixture(fixture.cwd);
+  return fixture;
 }
 
 test('resolve stable TypeScript 7', () => {
@@ -111,8 +127,38 @@ test('ignore the legacy TypeScript package API', () => {
     'bin/tsc',
     ['lib/tsc.js'],
   );
+  createLegacyNativeAliasFixture(fixture.cwd);
 
   expect(() => resolveTsgoBin(fixture.cwd)).toThrow('requires `typescript@^7`');
+});
+
+test('resolve the official TypeScript 7 side-by-side alias', () => {
+  const legacyFixture = createCompilerFixture(
+    'typescript',
+    { version: '6.0.3', bin: { tsc6: 'bin/tsc6' } },
+    'bin/tsc6',
+    ['lib/tsc6.js'],
+  );
+  createCompilerFixture(
+    '@typescript/native',
+    {
+      name: 'typescript',
+      version: '7.0.2',
+      type: 'module',
+      bin: { tsc: './bin/tsc' },
+    },
+    'bin/tsc',
+    ['lib/tsc.js'],
+    legacyFixture.cwd,
+  );
+
+  const resolvedBin = resolveTsgoBin(legacyFixture.cwd);
+
+  expect(
+    path
+      .normalize(resolvedBin)
+      .endsWith(path.normalize('@typescript/native/lib/tsc.js')),
+  ).toBe(true);
 });
 
 test('fall back to native preview for legacy TypeScript projects', () => {
@@ -122,6 +168,7 @@ test('fall back to native preview for legacy TypeScript projects', () => {
     'bin/tsc',
     ['lib/tsc.js'],
   );
+  createLegacyNativeAliasFixture(legacyFixture.cwd);
   createCompilerFixture(
     '@typescript/native-preview',
     { version: '7.0.0-dev.20260629.1', bin: { tsgo: 'bin/tsgo' } },


### PR DESCRIPTION
## Summary

- recognize the TypeScript team's documented `@typescript/native` alias after checking for a direct `typescript@7` dependency
- keep the existing `@typescript/native-preview` fallback
- run the real declaration fixture with TypeScript 7 and the TypeScript 6 compatibility API installed side-by-side
- document the side-by-side setup in both configuration guides

## Root cause

TypeScript 7 does not ship a stable Compiler API. Projects whose tooling still imports `typescript` are advised to install TypeScript 7 as `@typescript/native` and alias `typescript` to `@typescript/typescript6`. Father 4.6.27 only checked the `typescript` package name, saw version 6, and skipped the native compiler.

This was reproduced in the Umi monorepo and caused `dts.compiler: 'tsgo'` builds to fail.

## Validation

- `pnpm run build`
- focused tsgo suite: 8 tests passed, including a real side-by-side declaration build
- full suite: 15 test suites and 144 tests passed
- `pnpm install --frozen-lockfile --ignore-scripts`
- built Umi's `@umijs/utils` package successfully using this Father branch
- `git diff --check`
