### PR TITLE
fix: respect JSX runtime in utoopack UMD builds

### DIFF
--- a/src/builder/bundle/index.ts
+++ b/src/builder/bundle/index.ts
@@ -11,6 +11,7 @@ import {
   getBabelPresetReactOpts,
   getBabelStyledComponentsOpts,
   getBundleTargets,
+  getSWCTransformReactOpts,
 } from '../utils';
 
 const webpackBundler: typeof import('@umijs/bundler-webpack') = importLazy(
@@ -248,6 +249,10 @@ async function bundle(opts: IBundleOpts): Promise<void | IBundleWatcher> {
         const externals = convertExternalsToUtooPackExternals(config.externals);
         const copy = convertCopyConfig(config.copy, distPath);
         const entryPath = resolveEntryPath(path.join(opts.cwd, config.entry));
+        const reactOpts = getSWCTransformReactOpts(
+          opts.configProvider.pkg,
+          opts.cwd,
+        );
         const utooPackOpts: BundleOptions = {
           config: {
             entry: [
@@ -267,6 +272,10 @@ async function bundle(opts: IBundleOpts): Promise<void | IBundleWatcher> {
             sourceMaps: Boolean(config.sourcemap),
             externals,
             define: config.define,
+            react: {
+              runtime: reactOpts.runtime,
+              importSource: reactOpts.importSource,
+            },
             styles: {
               ...(config.extractCSS !== false ? {} : { inlineCss: {} }),
             },

--- a/tests/fixtures/build/classic-jsx/.fatherrc.ts
+++ b/tests/fixtures/build/classic-jsx/.fatherrc.ts
@@ -1,4 +1,12 @@
 export default {
   esm: {},
-  umd: {},
+  umd: {
+    externals: {
+      react: {
+        root: 'React',
+        commonjs: 'react',
+        commonjs2: 'react',
+      },
+    },
+  },
 };

--- a/tests/fixtures/build/classic-jsx/expect.ts
+++ b/tests/fixtures/build/classic-jsx/expect.ts
@@ -6,4 +6,9 @@ export default (files: Record<string, string>) => {
   // umd use classic jsx runtime
   expect(files['umd/index.min.js']).toContain('.createElement');
   expect(files['umd/index.min.js']).toContain('.Fragment');
+  expect(files['umd/index.min.js']).toContain('require("react")');
+  expect(files['umd/index.min.js']).not.toContain('ReactCurrentOwner');
+  expect(
+    /(\w)+\.jsx\)\(\1\.Fragment/.test(files['umd/index.min.js']),
+  ).toBeFalsy();
 };


### PR DESCRIPTION
## Summary

- forward the React JSX runtime and import source resolved by Father to `@utoo/pack`
- keep classic and automatic JSX behavior aligned between the Webpack and utoopack UMD paths
- strengthen the classic JSX fixture with an external React regression case

## Root cause

The utoopack adapter did not pass Father React transform options to `@utoo/pack`. Utoopack therefore defaulted to the automatic JSX runtime even when a project selected classic JSX. For antd this bundled the React 18 JSX runtime into the UMD artifact, which then failed when loaded with React 19 because it accessed `ReactCurrentOwner`.

## Impact

Classic JSX UMD builds now use `React.createElement` and no longer bundle a version-specific `react/jsx-runtime`. Projects using automatic JSX continue to use the automatic runtime.

## Validation

- `pnpm build`
- `pnpm jest tests/utoo-pack.build.test.ts --runInBand` — 31 passed
- Webpack classic and automatic JSX fixture tests — 2 passed
- antd UMD build with local Father — all four bundles compiled
- antd React 19.2.7 dist shard matching the failing CI job — 35 suites, 591 tests, and 507 snapshots passed

Related failure: https://github.com/ant-design/ant-design/actions/runs/29241255715/job/86788143161?pr=58682