### PR TITLE
feat: pass utoopack optimization config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -215,6 +215,29 @@ export default {
 
 开启 `utoopack` 之后，注意 webpack 相关的一些配置不再兼容，例如 chainWebpack 等。
 
+#### utoopack
+
+- 类型：`{ optimization?: object }`
+- 默认值：`undefined`
+
+向 Utoopack 透传 UMD 构建的优化配置。`minify` 和 `concatenateModules` 仍分别由 Father 的产物类型和 `umd.concatenateModules` 控制。
+
+```ts
+export default {
+  umd: {
+    bundler: 'utoopack',
+    utoopack: {
+      optimization: {
+        compress: {
+          passes: 3,
+        },
+        treeShaking: false,
+      },
+    },
+  },
+};
+```
+
 #### name
 
 - 类型：`string`

--- a/src/builder/bundle/index.ts
+++ b/src/builder/bundle/index.ts
@@ -4,7 +4,7 @@ import type { BundleOptions } from '@utoo/pack';
 import fs from 'fs';
 import path from 'path';
 import { getCachePath, logger } from '../../utils';
-import type { BundleConfigProvider } from '../config';
+import type { BundleConfigProvider, IBundleConfig } from '../config';
 import {
   convertCopyConfig,
   convertExternalsToUtooPackExternals,
@@ -39,6 +39,16 @@ interface IBundleOpts {
   buildDependencies?: string[];
   watch?: boolean;
   incremental?: boolean;
+}
+
+export function getUtooPackOptimization(
+  config: IBundleConfig,
+): NonNullable<BundleOptions['config']['optimization']> {
+  return {
+    ...config.utoopack?.optimization,
+    minify: config.jsMinifier !== JSMinifier.none,
+    concatenateModules: config.concatenateModules,
+  };
 }
 
 function resolveEntryPath(entryPath: string): string {
@@ -286,10 +296,7 @@ async function bundle(opts: IBundleOpts): Promise<void | IBundleWatcher> {
               assetModuleFilename: 'static/[name].[contenthash:8]',
               copy,
             },
-            optimization: {
-              minify: config.jsMinifier !== JSMinifier.none,
-              concatenateModules: config.concatenateModules,
-            },
+            optimization: getUtooPackOptimization(config),
             persistentCaching: false,
             nodePolyfill: true,
           },

--- a/src/features/configPlugins/schema.ts
+++ b/src/features/configPlugins/schema.ts
@@ -89,6 +89,9 @@ export function getSchemas(): Record<string, (Joi: Root) => any> {
           .items(Joi.object().pattern(Joi.string(), Joi.string()))
           .optional(),
         concatenateModules: Joi.boolean().optional(),
+        utoopack: Joi.object({
+          optimization: Joi.object().unknown(true).optional(),
+        }).optional(),
       }),
     prebundle: (Joi) =>
       Joi.object({

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import type Autoprefixer from '@umijs/bundler-webpack/compiled/autoprefixer';
 import type IWebpackChain from '@umijs/bundler-webpack/compiled/webpack-5-chain';
 import type { IConfig as IBundlerWebpackConfig } from '@umijs/bundler-webpack/dist/types';
 import type { IAdd, IModify, IServicePluginAPI, PluginAPI } from '@umijs/core';
+import type { BundleOptions as IUtooPackBundleOptions } from '@utoo/pack';
 import type { ITransformerItem } from './builder/bundless/loaders/javascript';
 import type {
   IBundleConfig,
@@ -113,6 +114,17 @@ export interface IFatherDtsConfig {
    * @experimental tsgo requires TypeScript 7 (direct or @typescript/native alias) or @typescript/native-preview
    */
   compiler?: `${IFatherDtsCompilerTypes}`;
+}
+
+export interface IFatherUtooPackConfig {
+  /**
+   * configure utoopack optimizations
+   * @note minify and concatenateModules are managed by father
+   */
+  optimization?: Omit<
+    NonNullable<IUtooPackBundleOptions['config']['optimization']>,
+    'minify' | 'concatenateModules'
+  >;
 }
 
 export interface IFatherBaseConfig {
@@ -291,6 +303,11 @@ export interface IFatherBundleConfig extends IFatherBaseConfig {
    * scope hoisting
    */
   concatenateModules?: boolean;
+
+  /**
+   * configure utoopack-specific options
+   */
+  utoopack?: IFatherUtooPackConfig;
 }
 
 export interface IFatherPreBundleConfig {

--- a/tests/utoo-pack.config.test.ts
+++ b/tests/utoo-pack.config.test.ts
@@ -1,0 +1,44 @@
+import { JSMinifier } from '@umijs/bundler-webpack/dist/types';
+import Joi from '@umijs/utils/compiled/@hapi/joi';
+import { getUtooPackOptimization } from '../src/builder/bundle';
+import type { IBundleConfig } from '../src/builder/config';
+import { getSchemas } from '../src/features/configPlugins/schema';
+import { IFatherBuildTypes } from '../src/types';
+
+test('utoopack: passes optimization config through', () => {
+  const config = {
+    type: IFatherBuildTypes.BUNDLE,
+    entry: 'src/index.ts',
+    output: { path: 'dist', filename: 'index.min.js' },
+    jsMinifier: JSMinifier.terser,
+    concatenateModules: true,
+    utoopack: {
+      optimization: {
+        compress: { passes: 3 },
+        treeShaking: false,
+      },
+    },
+  } satisfies IBundleConfig;
+
+  expect(getUtooPackOptimization(config)).toEqual({
+    compress: { passes: 3 },
+    treeShaking: false,
+    minify: true,
+    concatenateModules: true,
+  });
+});
+
+test('utoopack: accepts optimization config in father schema', () => {
+  const schema = getSchemas().umd(Joi);
+  const result = schema.validate({
+    bundler: 'utoopack',
+    utoopack: {
+      optimization: {
+        compress: { passes: 3 },
+        treeShaking: false,
+      },
+    },
+  });
+
+  expect(result.error).toBeUndefined();
+});


### PR DESCRIPTION
## Summary

- add typed `umd.utoopack.optimization` config passthrough
- keep `minify` and `concatenateModules` controlled by Father
- document the config and cover schema/merge behavior with tests

This lets Father UMD builds opt into native Utoopack optimizations without adding a second JavaScript minification pass in Father, preserving build performance and keeping optimization ownership in Utoopack.

## Test plan

- `pnpm build`
- `pnpm jest tests/utoo-pack.config.test.ts --runInBand`
- `pnpm jest tests/utoo-pack.build.test.ts --runInBand`
- `pnpm test -- --runInBand` (16 suites, 146 tests)