### PR TITLE
feat: support utoopack config passthrough

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -215,6 +215,30 @@ export default {
 
 开启 `utoopack` 之后，注意 webpack 相关的一些配置不再兼容，例如 chainWebpack 等。
 
+#### utoopack
+
+- 类型：`Partial<@utoo/pack Config>`
+- 默认值：`undefined`
+
+向 Utoopack 透传 UMD 构建配置。用户配置会与 Father 生成的默认配置进行深度合并，同名字段以用户配置为准。
+
+```ts
+export default {
+  umd: {
+    bundler: 'utoopack',
+    utoopack: {
+      optimization: {
+        extractComments: true,
+        compress: {
+          passes: 3,
+        },
+        treeShaking: false,
+      },
+    },
+  },
+};
+```
+
 #### name
 
 - 类型：`string`

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@umijs/case-sensitive-paths-webpack-plugin": "^1.0.1",
     "@umijs/core": "^4.6.75",
     "@umijs/utils": "^4.6.75",
-    "@utoo/pack": "1.4.24",
+    "@utoo/pack": "1.4.25-alpha.3",
     "@vercel/ncc": "0.33.3",
     "babel-plugin-dynamic-import-node": "2.3.3",
     "babel-plugin-module-resolver": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@umijs/case-sensitive-paths-webpack-plugin": "^1.0.1",
     "@umijs/core": "^4.6.75",
     "@umijs/utils": "^4.6.75",
-    "@utoo/pack": "1.4.25-alpha.3",
+    "@utoo/pack": "1.4.25",
     "@vercel/ncc": "0.33.3",
     "babel-plugin-dynamic-import-node": "2.3.3",
     "babel-plugin-module-resolver": "4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^4.6.75
         version: 4.6.75
       '@utoo/pack':
-        specifier: 1.4.24
-        version: 1.4.24(less-loader@12.3.0)(less@4.3.0)(postcss@8.4.31)(resolve-url-loader@5.0.0)(sass-loader@13.3.3)(sass@1.54.0)(styled-jsx@5.1.7)
+        specifier: 1.4.25-alpha.3
+        version: 1.4.25-alpha.3(less-loader@12.3.0)(less@4.3.0)(postcss@8.4.31)(resolve-url-loader@5.0.0)(sass-loader@13.3.3)(sass@1.54.0)(styled-jsx@5.1.7)
       '@vercel/ncc':
         specifier: 0.33.3
         version: 0.33.3
@@ -4266,8 +4266,8 @@ packages:
       pino: 7.11.0
     dev: false
 
-  /@utoo/pack-darwin-arm64@1.4.24:
-    resolution: {integrity: sha512-go9PVMdI6zjhKk7WElVMRYOmMIFP22UYY0chZMHqrDLBaVlbDImSicyoLQmSdr5iYlBgXMhqq3tKqMmmZlaHgA==}
+  /@utoo/pack-darwin-arm64@1.4.25-alpha.3:
+    resolution: {integrity: sha512-qH+gUfu9PvP3rI8fVJlmHvApBHiGUhAb1Hv0rOwjgYVNVDoPTXEmmo1Cy+Xw/oGZMUgdsTVVMNpj3hDonNxPsQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
@@ -4275,8 +4275,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-darwin-x64@1.4.24:
-    resolution: {integrity: sha512-W2sapQjfsgiGKAbxWem+oAgO/7anTMZYY6vvYgXXlUx75kxQZzgT1GZGrWF3UwgJ5z33q6AA9sJAWGTK9fOxYg==}
+  /@utoo/pack-darwin-x64@1.4.25-alpha.3:
+    resolution: {integrity: sha512-GiIC87zePxebXHPKGIyeP01VTUZ/y/XjmlPP6R6RJFTTBVcY1h67umwTFTgioaFM9PY6rcOQLOXE9CkCaRdqJA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
@@ -4284,8 +4284,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-linux-arm64-gnu@1.4.24:
-    resolution: {integrity: sha512-+IlpQ+PUDri9gth3nfEjDlgmpllGw28KBx/M76AT4k37a5srYZFQ9VE6aBHSzUyevlSsg2hY25M9veXNzGjJdA==}
+  /@utoo/pack-linux-arm64-gnu@1.4.25-alpha.3:
+    resolution: {integrity: sha512-1NPTF9BNrK6yRBehD48/0rA1IdVqknyAOOiohnrx+8QnRMrCuxDLBbwg79+yTi3+SCI7e5p/Pe8HXqs+NSgLqA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -4293,8 +4293,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-linux-arm64-musl@1.4.24:
-    resolution: {integrity: sha512-h/+rmE4W/ExqI/tRHVJyAYBawHgfrWLlVyMdoq/i12L5GvuPZB1ZrX0L4s9B5Air3EttwWMTY4eFTzst+AQ4sg==}
+  /@utoo/pack-linux-arm64-musl@1.4.25-alpha.3:
+    resolution: {integrity: sha512-87GnmLQu8+lvy7hcrdj3UdH6LOPxyT9oa2agBBYZiyjmqy3IvI49bz8q5TQYhAMjvGtyNITUUbCCm/TXYylrgQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -4302,8 +4302,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-linux-x64-gnu@1.4.24:
-    resolution: {integrity: sha512-lzNtoxW4d7+S7VJvqxlQkrzmDdZK6jj+cdImOTgT9Dt4WUf8q0VTGJeh76fJqUcWh92dOBFvAG2CjLAHFOr81Q==}
+  /@utoo/pack-linux-x64-gnu@1.4.25-alpha.3:
+    resolution: {integrity: sha512-U0WSwpAcOrSVVAr2JS3jfu2po0WNW6j1h6jbQMFhSlEyM9JwQrfgJ8fkiz2W1BqIBgYZEPy27jFI5dLfILpsvw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -4311,8 +4311,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-linux-x64-musl@1.4.24:
-    resolution: {integrity: sha512-zLjipsIdrT2quu0HrxXKhdvdieg8vSCNm5Zcw7vI1dimBocq7t01FcULqmgeP+oPMuX26qTP/L14hIoE5sFT0w==}
+  /@utoo/pack-linux-x64-musl@1.4.25-alpha.3:
+    resolution: {integrity: sha512-rh1olYCpWE4rkdgFnO7Jx5ZvvFaVGbdjPlcG8579Zo+6rY7B7Kumr6vOrjGN2D8DEUewWeMt6u3DwqFJROzM8A==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -4320,16 +4320,16 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-shared@1.4.24:
-    resolution: {integrity: sha512-6A7anvwZn4CVrdFLgNadRPTjYZMKFDdxIBXOKONJ5V5wcOYjrjbTJ0ZzqJMv8kBicv2huDjMyYFmtFAcegiHCg==}
+  /@utoo/pack-shared@1.4.25-alpha.3:
+    resolution: {integrity: sha512-MaGvEkw0OTWKpAU+GD0omMUqGYS2L9d/enIkoBuvHS6yLgGRd86CQWiHlu6cokeGv6fw2E+nym/U/cdRnGmfNg==}
     engines: {node: '>= 20'}
     dependencies:
       '@babel/code-frame': 7.22.5
       picocolors: 1.1.1
     dev: false
 
-  /@utoo/pack-win32-x64-msvc@1.4.24:
-    resolution: {integrity: sha512-lXt87YBz5n4FuF5vONAoRXTBRfj2Y7UeIH1Y2r5h90KiP+706dPTFxsO1CFJGKSZMH1XABxuIn5L6cxytG0npg==}
+  /@utoo/pack-win32-x64-msvc@1.4.25-alpha.3:
+    resolution: {integrity: sha512-bWl1X3GCDHLnfGaNauCl0ddbbB5XiKUTPgWZYI+So0ZN8cVG4K47pXZ6K0VwupGC7R1NNot4UgdSWoi9+4YWZw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
@@ -4337,8 +4337,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack@1.4.24(less-loader@12.3.0)(less@4.3.0)(postcss@8.4.31)(resolve-url-loader@5.0.0)(sass-loader@13.3.3)(sass@1.54.0)(styled-jsx@5.1.7):
-    resolution: {integrity: sha512-rA8inrVOILO3CkCfiWvU4eYAics8n/AD7E9/estKjZ36n98MpEW70cRwzQ3iGaG1yuvMmLIrRelpzS5bK3OQVQ==}
+  /@utoo/pack@1.4.25-alpha.3(less-loader@12.3.0)(less@4.3.0)(postcss@8.4.31)(resolve-url-loader@5.0.0)(sass-loader@13.3.3)(sass@1.54.0)(styled-jsx@5.1.7):
+    resolution: {integrity: sha512-s8jz08dy8M7z5VfBAX7lAEcI5W4loZ2uHDDbffMISWHdJUmL88J/nOt/LurAeYYq+RN5p3z3SqAa7pkT2++W/A==}
     engines: {node: '>= 20'}
     peerDependencies:
       less: ^4.0.0
@@ -4356,7 +4356,7 @@ packages:
       '@hono/node-server': 1.19.11(hono@4.12.8)
       '@hono/node-ws': 1.3.0(@hono/node-server@1.19.11)(hono@4.12.8)
       '@swc/helpers': 0.5.15
-      '@utoo/pack-shared': 1.4.24
+      '@utoo/pack-shared': 1.4.25-alpha.3
       domparser-rs: 0.0.7
       find-up: 4.1.0
       get-port: 5.1.1
@@ -4374,13 +4374,13 @@ packages:
       styled-jsx: 5.1.7(@babel/core@7.29.0)(react@16.14.0)
       ws: 8.18.2
     optionalDependencies:
-      '@utoo/pack-darwin-arm64': 1.4.24
-      '@utoo/pack-darwin-x64': 1.4.24
-      '@utoo/pack-linux-arm64-gnu': 1.4.24
-      '@utoo/pack-linux-arm64-musl': 1.4.24
-      '@utoo/pack-linux-x64-gnu': 1.4.24
-      '@utoo/pack-linux-x64-musl': 1.4.24
-      '@utoo/pack-win32-x64-msvc': 1.4.24
+      '@utoo/pack-darwin-arm64': 1.4.25-alpha.3
+      '@utoo/pack-darwin-x64': 1.4.25-alpha.3
+      '@utoo/pack-linux-arm64-gnu': 1.4.25-alpha.3
+      '@utoo/pack-linux-arm64-musl': 1.4.25-alpha.3
+      '@utoo/pack-linux-x64-gnu': 1.4.25-alpha.3
+      '@utoo/pack-linux-x64-musl': 1.4.25-alpha.3
+      '@utoo/pack-win32-x64-msvc': 1.4.25-alpha.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^4.6.75
         version: 4.6.75
       '@utoo/pack':
-        specifier: 1.4.25-alpha.3
-        version: 1.4.25-alpha.3(less-loader@12.3.0)(less@4.3.0)(postcss@8.4.31)(resolve-url-loader@5.0.0)(sass-loader@13.3.3)(sass@1.54.0)(styled-jsx@5.1.7)
+        specifier: 1.4.25
+        version: 1.4.25(less-loader@12.3.0)(less@4.3.0)(postcss@8.4.31)(resolve-url-loader@5.0.0)(sass-loader@13.3.3)(sass@1.54.0)(styled-jsx@5.1.7)
       '@vercel/ncc':
         specifier: 0.33.3
         version: 0.33.3
@@ -4266,8 +4266,8 @@ packages:
       pino: 7.11.0
     dev: false
 
-  /@utoo/pack-darwin-arm64@1.4.25-alpha.3:
-    resolution: {integrity: sha512-qH+gUfu9PvP3rI8fVJlmHvApBHiGUhAb1Hv0rOwjgYVNVDoPTXEmmo1Cy+Xw/oGZMUgdsTVVMNpj3hDonNxPsQ==}
+  /@utoo/pack-darwin-arm64@1.4.25:
+    resolution: {integrity: sha512-jKtEPccaVgHjEUqq+6tQGpqINuxGu2GHI12ASio4WRQ8pJAH02cH2m5Chah4aTBQ7JpvY4HGo4PqYkKLk9EhYA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
@@ -4275,8 +4275,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-darwin-x64@1.4.25-alpha.3:
-    resolution: {integrity: sha512-GiIC87zePxebXHPKGIyeP01VTUZ/y/XjmlPP6R6RJFTTBVcY1h67umwTFTgioaFM9PY6rcOQLOXE9CkCaRdqJA==}
+  /@utoo/pack-darwin-x64@1.4.25:
+    resolution: {integrity: sha512-tSXXsN4OhiuOkApXBzPGBQBoSAHhGdRdUH57BnOb1awoPOs0pblmGkWaWnLfIZ+U9226fJ2kJWmqwNnJhDhSMw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
@@ -4284,8 +4284,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-linux-arm64-gnu@1.4.25-alpha.3:
-    resolution: {integrity: sha512-1NPTF9BNrK6yRBehD48/0rA1IdVqknyAOOiohnrx+8QnRMrCuxDLBbwg79+yTi3+SCI7e5p/Pe8HXqs+NSgLqA==}
+  /@utoo/pack-linux-arm64-gnu@1.4.25:
+    resolution: {integrity: sha512-W/db5UdNe0+DrIu1+8epz5vLuVYlx9kNjuEwVQ0hDOPJRZyxox1uUcOgxkBObBDJ+PeTeKMbGteHopZIA5rkRA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -4293,8 +4293,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-linux-arm64-musl@1.4.25-alpha.3:
-    resolution: {integrity: sha512-87GnmLQu8+lvy7hcrdj3UdH6LOPxyT9oa2agBBYZiyjmqy3IvI49bz8q5TQYhAMjvGtyNITUUbCCm/TXYylrgQ==}
+  /@utoo/pack-linux-arm64-musl@1.4.25:
+    resolution: {integrity: sha512-i+JzJ7c/JGwRcJcjaQdQCISmHLsNaps8JK/YMTLo+rsjl6kJdycR6bHnfL9WIdgBdY5RPA83nF88vh8SphNgZA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -4302,8 +4302,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-linux-x64-gnu@1.4.25-alpha.3:
-    resolution: {integrity: sha512-U0WSwpAcOrSVVAr2JS3jfu2po0WNW6j1h6jbQMFhSlEyM9JwQrfgJ8fkiz2W1BqIBgYZEPy27jFI5dLfILpsvw==}
+  /@utoo/pack-linux-x64-gnu@1.4.25:
+    resolution: {integrity: sha512-Si1WuDA3Cki1jUSfWd5B7NbtxY35Haq3K21lfM/uGDFHxsugJulVlKptG5KXVo4bGDv9d5U/aigKxfasWm4yLg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -4311,8 +4311,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-linux-x64-musl@1.4.25-alpha.3:
-    resolution: {integrity: sha512-rh1olYCpWE4rkdgFnO7Jx5ZvvFaVGbdjPlcG8579Zo+6rY7B7Kumr6vOrjGN2D8DEUewWeMt6u3DwqFJROzM8A==}
+  /@utoo/pack-linux-x64-musl@1.4.25:
+    resolution: {integrity: sha512-HZz5i2dIO84duCW0GEdDb9OUFnQn3bNtyTIuwqqSneBEI5AW5Swh5dmcecoyC3kZGkbe4dcIVrDmdl+TDHzWeQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -4320,16 +4320,16 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack-shared@1.4.25-alpha.3:
-    resolution: {integrity: sha512-MaGvEkw0OTWKpAU+GD0omMUqGYS2L9d/enIkoBuvHS6yLgGRd86CQWiHlu6cokeGv6fw2E+nym/U/cdRnGmfNg==}
+  /@utoo/pack-shared@1.4.25:
+    resolution: {integrity: sha512-f7WOz0d+LwlNGNqG6zUGgmSILxxjpPsE6RM0eSSw+DSi+xOMHftcYZP/IZsvI8emcFMmjXWVvoVc+vmNRTjoGQ==}
     engines: {node: '>= 20'}
     dependencies:
       '@babel/code-frame': 7.22.5
       picocolors: 1.1.1
     dev: false
 
-  /@utoo/pack-win32-x64-msvc@1.4.25-alpha.3:
-    resolution: {integrity: sha512-bWl1X3GCDHLnfGaNauCl0ddbbB5XiKUTPgWZYI+So0ZN8cVG4K47pXZ6K0VwupGC7R1NNot4UgdSWoi9+4YWZw==}
+  /@utoo/pack-win32-x64-msvc@1.4.25:
+    resolution: {integrity: sha512-vSIMbYGxHKG/jlC59Jv8qwYb9/mlhs6MWiox1dv9MH3rdcg8lOyyG94+M238jIPS4lJeEzTVSAhud3eVMzvrsw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
@@ -4337,8 +4337,8 @@ packages:
     dev: false
     optional: true
 
-  /@utoo/pack@1.4.25-alpha.3(less-loader@12.3.0)(less@4.3.0)(postcss@8.4.31)(resolve-url-loader@5.0.0)(sass-loader@13.3.3)(sass@1.54.0)(styled-jsx@5.1.7):
-    resolution: {integrity: sha512-s8jz08dy8M7z5VfBAX7lAEcI5W4loZ2uHDDbffMISWHdJUmL88J/nOt/LurAeYYq+RN5p3z3SqAa7pkT2++W/A==}
+  /@utoo/pack@1.4.25(less-loader@12.3.0)(less@4.3.0)(postcss@8.4.31)(resolve-url-loader@5.0.0)(sass-loader@13.3.3)(sass@1.54.0)(styled-jsx@5.1.7):
+    resolution: {integrity: sha512-QwRBloV7RH9dTEZuA1OuUCnrj1Y38SA1TdeP5n7WPt4vN35cCq2Z37kBwB1hThqd2KOC7omw/mz9RUDlBnQV5w==}
     engines: {node: '>= 20'}
     peerDependencies:
       less: ^4.0.0
@@ -4356,7 +4356,7 @@ packages:
       '@hono/node-server': 1.19.11(hono@4.12.8)
       '@hono/node-ws': 1.3.0(@hono/node-server@1.19.11)(hono@4.12.8)
       '@swc/helpers': 0.5.15
-      '@utoo/pack-shared': 1.4.25-alpha.3
+      '@utoo/pack-shared': 1.4.25
       domparser-rs: 0.0.7
       find-up: 4.1.0
       get-port: 5.1.1
@@ -4374,13 +4374,13 @@ packages:
       styled-jsx: 5.1.7(@babel/core@7.29.0)(react@16.14.0)
       ws: 8.18.2
     optionalDependencies:
-      '@utoo/pack-darwin-arm64': 1.4.25-alpha.3
-      '@utoo/pack-darwin-x64': 1.4.25-alpha.3
-      '@utoo/pack-linux-arm64-gnu': 1.4.25-alpha.3
-      '@utoo/pack-linux-arm64-musl': 1.4.25-alpha.3
-      '@utoo/pack-linux-x64-gnu': 1.4.25-alpha.3
-      '@utoo/pack-linux-x64-musl': 1.4.25-alpha.3
-      '@utoo/pack-win32-x64-msvc': 1.4.25-alpha.3
+      '@utoo/pack-darwin-arm64': 1.4.25
+      '@utoo/pack-darwin-x64': 1.4.25
+      '@utoo/pack-linux-arm64-gnu': 1.4.25
+      '@utoo/pack-linux-arm64-musl': 1.4.25
+      '@utoo/pack-linux-x64-gnu': 1.4.25
+      '@utoo/pack-linux-x64-musl': 1.4.25
+      '@utoo/pack-win32-x64-msvc': 1.4.25
     transitivePeerDependencies:
       - bufferutil
       - supports-color

--- a/src/builder/bundle/index.ts
+++ b/src/builder/bundle/index.ts
@@ -4,7 +4,7 @@ import type { BundleOptions } from '@utoo/pack';
 import fs from 'fs';
 import path from 'path';
 import { getCachePath, logger } from '../../utils';
-import type { BundleConfigProvider } from '../config';
+import type { BundleConfigProvider, IBundleConfig } from '../config';
 import {
   convertCopyConfig,
   convertExternalsToUtooPackExternals,
@@ -39,6 +39,13 @@ interface IBundleOpts {
   buildDependencies?: string[];
   watch?: boolean;
   incremental?: boolean;
+}
+
+export function mergeUtooPackConfig(
+  config: BundleOptions['config'],
+  userConfig?: IBundleConfig['utoopack'],
+): BundleOptions['config'] {
+  return lodash.merge({}, config, userConfig);
 }
 
 function resolveEntryPath(entryPath: string): string {
@@ -254,45 +261,48 @@ async function bundle(opts: IBundleOpts): Promise<void | IBundleWatcher> {
           opts.cwd,
         );
         const utooPackOpts: BundleOptions = {
-          config: {
-            entry: [
-              {
-                name: entryName,
-                import: entryPath,
-                library: {
-                  name: config.name,
-                  export: [],
+          config: mergeUtooPackConfig(
+            {
+              entry: [
+                {
+                  name: entryName,
+                  import: entryPath,
+                  library: {
+                    name: config.name,
+                    export: [],
+                  },
                 },
+              ],
+              mode: opts.watch ? 'development' : 'production',
+              resolve: {
+                alias: config.alias,
               },
-            ],
-            mode: opts.watch ? 'development' : 'production',
-            resolve: {
-              alias: config.alias,
+              sourceMaps: Boolean(config.sourcemap),
+              externals,
+              define: config.define,
+              react: {
+                runtime: reactOpts.runtime,
+                importSource: reactOpts.importSource,
+              },
+              styles: {
+                ...(config.extractCSS !== false ? {} : { inlineCss: {} }),
+              },
+              output: {
+                path: distPath,
+                filename: config.output.filename,
+                cssFilename: '[name].css',
+                assetModuleFilename: 'static/[name].[contenthash:8]',
+                copy,
+              },
+              optimization: {
+                minify: config.jsMinifier !== JSMinifier.none,
+                concatenateModules: config.concatenateModules,
+              },
+              persistentCaching: false,
+              nodePolyfill: true,
             },
-            sourceMaps: Boolean(config.sourcemap),
-            externals,
-            define: config.define,
-            react: {
-              runtime: reactOpts.runtime,
-              importSource: reactOpts.importSource,
-            },
-            styles: {
-              ...(config.extractCSS !== false ? {} : { inlineCss: {} }),
-            },
-            output: {
-              path: distPath,
-              filename: config.output.filename,
-              cssFilename: '[name].css',
-              assetModuleFilename: 'static/[name].[contenthash:8]',
-              copy,
-            },
-            optimization: {
-              minify: config.jsMinifier !== JSMinifier.none,
-              concatenateModules: config.concatenateModules,
-            },
-            persistentCaching: false,
-            nodePolyfill: true,
-          },
+            config.utoopack,
+          ),
           watch: {
             enable: opts.watch ?? false,
           },

--- a/src/features/configPlugins/schema.ts
+++ b/src/features/configPlugins/schema.ts
@@ -89,6 +89,7 @@ export function getSchemas(): Record<string, (Joi: Root) => any> {
           .items(Joi.object().pattern(Joi.string(), Joi.string()))
           .optional(),
         concatenateModules: Joi.boolean().optional(),
+        utoopack: Joi.object().unknown(true).optional(),
       }),
     prebundle: (Joi) =>
       Joi.object({

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import type Autoprefixer from '@umijs/bundler-webpack/compiled/autoprefixer';
 import type IWebpackChain from '@umijs/bundler-webpack/compiled/webpack-5-chain';
 import type { IConfig as IBundlerWebpackConfig } from '@umijs/bundler-webpack/dist/types';
 import type { IAdd, IModify, IServicePluginAPI, PluginAPI } from '@umijs/core';
+import type { BundleOptions as IUtooPackBundleOptions } from '@utoo/pack';
 import type { ITransformerItem } from './builder/bundless/loaders/javascript';
 import type {
   IBundleConfig,
@@ -114,6 +115,8 @@ export interface IFatherDtsConfig {
    */
   compiler?: `${IFatherDtsCompilerTypes}`;
 }
+
+export type IFatherUtooPackConfig = Partial<IUtooPackBundleOptions['config']>;
 
 export interface IFatherBaseConfig {
   /**
@@ -291,6 +294,11 @@ export interface IFatherBundleConfig extends IFatherBaseConfig {
    * scope hoisting
    */
   concatenateModules?: boolean;
+
+  /**
+   * configure utoopack
+   */
+  utoopack?: IFatherUtooPackConfig;
 }
 
 export interface IFatherPreBundleConfig {

--- a/tests/fixtures/build/utoopack-extract-comments/.fatherrc.ts
+++ b/tests/fixtures/build/utoopack-extract-comments/.fatherrc.ts
@@ -1,0 +1,11 @@
+export default {
+  umd: {
+    bundler: 'utoopack',
+    name: 'extract_comments',
+    utoopack: {
+      optimization: {
+        extractComments: true,
+      },
+    },
+  },
+};

--- a/tests/fixtures/build/utoopack-extract-comments/expect.ts
+++ b/tests/fixtures/build/utoopack-extract-comments/expect.ts
@@ -1,0 +1,10 @@
+export default (files: Record<string, string>) => {
+  const filename = 'utoopack-extract-comments.min.js';
+
+  expect(files[`umd/${filename}`]).toContain(
+    `For license information please see ${filename}.LICENSE.txt`,
+  );
+  expect(files[`umd/${filename}.LICENSE.txt`]).toContain(
+    '/*! Father license */',
+  );
+};

--- a/tests/fixtures/build/utoopack-extract-comments/package.json
+++ b/tests/fixtures/build/utoopack-extract-comments/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "utoopack-extract-comments",
+  "version": "1.0.0"
+}

--- a/tests/fixtures/build/utoopack-extract-comments/src/index.js
+++ b/tests/fixtures/build/utoopack-extract-comments/src/index.js
@@ -1,0 +1,4 @@
+/*! Father license */
+globalThis.__fatherLicense = true;
+
+export default 1;

--- a/tests/utoo-pack.config.test.ts
+++ b/tests/utoo-pack.config.test.ts
@@ -1,0 +1,59 @@
+import Joi from '@umijs/utils/compiled/@hapi/joi';
+import { mergeUtooPackConfig } from '../src/builder/bundle';
+import type { IBundleConfig } from '../src/builder/config';
+import { getSchemas } from '../src/features/configPlugins/schema';
+
+test('utoopack: merges user config into father defaults', () => {
+  const defaults = {
+    entry: [],
+    output: { path: 'dist', filename: 'index.min.js' },
+    optimization: {
+      minify: true,
+      concatenateModules: true,
+    },
+    persistentCaching: false,
+  } satisfies IBundleConfig['utoopack'] & { entry: [] };
+
+  expect(
+    mergeUtooPackConfig(defaults, {
+      output: { publicPath: '/assets/' },
+      optimization: {
+        extractComments: true,
+        compress: { passes: 3 },
+      },
+      stats: false,
+    }),
+  ).toEqual({
+    entry: [],
+    output: {
+      path: 'dist',
+      filename: 'index.min.js',
+      publicPath: '/assets/',
+    },
+    optimization: {
+      minify: true,
+      concatenateModules: true,
+      extractComments: true,
+      compress: { passes: 3 },
+    },
+    persistentCaching: false,
+    stats: false,
+  });
+});
+
+test('utoopack: accepts config passthrough in father schema', () => {
+  const schema = getSchemas().umd(Joi);
+  const result = schema.validate({
+    bundler: 'utoopack',
+    utoopack: {
+      optimization: {
+        extractComments: true,
+        compress: { passes: 3 },
+        treeShaking: false,
+      },
+      stats: false,
+    },
+  });
+
+  expect(result.error).toBeUndefined();
+});


### PR DESCRIPTION
## Summary

- add an optional `umd.utoopack` config passthrough and deep-merge it after Father's generated defaults
- bump `@utoo/pack` to `1.4.25`
- document the config and cover schema, merge behavior, and `optimization.extractComments` output

## Usage

```ts
export default {
  umd: {
    bundler: 'utoopack',
    utoopack: {
      optimization: {
        extractComments: true,
      },
    },
  },
};
```

## Test plan

- `pnpm build`
- `pnpm jest tests/utoo-pack.config.test.ts tests/utoo-pack.build.test.ts --runInBand`
- `pnpm jest tests/g.commitlint.test.ts --runInBand`

Note: a local full-suite run reached 147/148 tests; the remaining existing generator fixture test races with other generator suites when run concurrently and passes on its own.
