### PR TITLE
feat: add automatic module extensions for bundless builds

### DIFF
--- a/docs/config.en-US.md
+++ b/docs/config.en-US.md
@@ -153,6 +153,36 @@ Father provides build configurations based on **output types**:
   - **ESM** → Default is `dist/esm`
   - **CJS** → Default is `dist/cjs`
 
+### **fullySpecified**
+
+- **Type**: `boolean`
+- **Default**: `false`
+- **ESM only**: applies to the entire ESM build, including `overrides`
+
+Completes relative imports, re-exports and literal `import()` paths with runtime extensions or directory indexes, such as `./utils` → `./utils.js` or `./utils/index.js`, and aligns declaration specifiers. Paths follow actual output locations, including relocated `overrides`. Unresolved extensionless relative imports produce an error.
+
+Works with Babel, esbuild, SWC, parallel builds, caching and watch, preserving JavaScript and declaration source maps. It does not change external dependency paths, output filenames or package.json.
+
+### **resolveDepSubpath**
+
+- **Type**: `boolean`
+- **Default**: `false`
+- **ESM only**: applies to the entire ESM build, including `overrides`
+
+Completes subpaths of dependencies without `exports`, for example `dayjs/plugin/weekday` → `dayjs/plugin/weekday.js`, in both JavaScript and declarations. Package roots, dependencies with an `exports` map, and unresolved dependencies retain their original specifiers. This option is independent of `fullySpecified`; enable it when compatibility with these legacy dependencies is needed.
+
+### **outputPackageType**
+
+- **Type**: `'module'`
+- **Default**: `undefined` (do not generate or modify package metadata)
+- **ESM only**: applies to the entire ESM build, including `overrides`
+
+Writes a package.json with `"type": "module"` in ESM output directories, including relocated `overrides`. Package.json files copied into the output also receive this field, preserving other metadata. Existing `.js` and `.d.ts` filenames are retained; Node.js and TypeScript interpret these files as ESM. ESM and CJS must use separate, non-overlapping output directories when this option is enabled.
+
+All three options require explicit configuration. Neither `exports.import` nor the root package.json `type` enables them automatically. Existing configurations retain their build behavior. After disabling an option, perform a default clean build to avoid retaining previously generated files with `clean: false`.
+
+These options do not convert CommonJS dependencies into ESM or make CSS imports and browser-only APIs available in Node.js. See the [native ESM publishing example](./guide/esm-cjs.en-US.md#native-esm-in-nodejs).
+
 ### **transformer**
 
 - **Type**: `"babel" | "esbuild" | "swc"`

--- a/docs/config.en-US.md
+++ b/docs/config.en-US.md
@@ -153,15 +153,36 @@ Father provides build configurations based on **output types**:
   - **ESM** → Default is `dist/esm`
   - **CJS** → Default is `dist/cjs`
 
-### **fullySpecified**
+### **autoExtension**
 
 - **Type**: `boolean`
 - **Default**: `false`
-- **ESM only**: applies to the entire ESM build, including `overrides`
+- Supports `esm`, `cjs` and `overrides`
 
-Completes relative imports, re-exports and literal `import()` paths with runtime extensions or directory indexes, such as `./utils` → `./utils.js` or `./utils/index.js`, and aligns declaration specifiers. Paths follow actual output locations, including relocated `overrides`. Unresolved extensionless relative imports produce an error.
+Chooses JavaScript extensions according to the package type and output format, and matches generated or copied declaration extensions:
 
-Works with Babel, esbuild, SWC, parallel builds, caching and watch, preserving JavaScript and declaration source maps. It does not change external dependency paths, output filenames or package.json.
+| Package type                 | ESM output        | CJS output        |
+| ---------------------------- | ----------------- | ----------------- |
+| `type: "module"`             | `.js` / `.d.ts`   | `.cjs` / `.d.cts` |
+| `type: "commonjs"` or absent | `.mjs` / `.d.mts` | `.js` / `.d.ts`   |
+
+The filename policy follows [Rslib's autoExtension](https://rslib.rs/config/lib/auto-extension), but defaults to off for Father 4 compatibility. Father also matches declaration extensions when enabled, avoiding type entry points such as `.mjs` files without corresponding `.d.mts` files.
+
+The root package.json supplies the default package type. Package.json files copied from sources define their own output scopes, including relocated `overrides`. Explicit `.mjs`, `.cjs`, `.d.mts` and `.d.cts` files retain their extensions. No package.json is generated or modified.
+
+Enabling this option also enables `redirect.js.extension` and `redirect.dts.extension` by default so module references match the emitted files. Supports Babel, esbuild, SWC, parallel builds, caching, watch and source maps. After changing package types or output configuration, or disabling the option, restart with a default clean build to avoid retaining old files with `clean: false` or an existing watch process.
+
+### **redirect**
+
+- **Type**: `{ js?: { extension?: boolean }; dts?: { extension?: boolean } }`
+- **Default**: each `extension` follows `autoExtension`, otherwise `false`
+- Supports `esm`, `cjs` and `overrides`
+
+Uses [Rslib's redirect](https://rslib.rs/config/lib/redirect) naming to control relative module references in JavaScript and declarations independently. `js.extension` handles imports, re-exports, literal `import()` and literal `require()` in CJS output. `dts.extension` handles declaration imports, re-exports, type imports and module augmentations.
+
+For example, `./utils` becomes `./utils.mjs` or `./utils/index.mjs` according to emitted files; existing `./utils.js` references are updated too. Paths follow actual output locations, including relocated `overrides`. Unresolved extensionless relative references produce an error. This option does not change filenames or external dependency paths.
+
+Enable `redirect` alone to complete internal references while retaining `.js` filenames. Explicitly disable either `extension` to leave those references for a consumer's build tool to process.
 
 ### **resolveDepSubpath**
 
@@ -169,19 +190,9 @@ Works with Babel, esbuild, SWC, parallel builds, caching and watch, preserving J
 - **Default**: `false`
 - **ESM only**: applies to the entire ESM build, including `overrides`
 
-Completes subpaths of dependencies without `exports`, for example `dayjs/plugin/weekday` → `dayjs/plugin/weekday.js`, in both JavaScript and declarations. Package roots, dependencies with an `exports` map, and unresolved dependencies retain their original specifiers. This option is independent of `fullySpecified`; enable it when compatibility with these legacy dependencies is needed.
+Completes subpaths of dependencies without `exports`, for example `dayjs/plugin/weekday` → `dayjs/plugin/weekday.js`, in JavaScript and declarations. Package roots, dependencies with `exports`, and unresolved dependencies retain their specifiers. Like tsdown's `deps.resolveDepSubpath`, this is independent of internal reference completion; enable it when legacy dependencies need it.
 
-### **outputPackageType**
-
-- **Type**: `'module'`
-- **Default**: `undefined` (do not generate or modify package metadata)
-- **ESM only**: applies to the entire ESM build, including `overrides`
-
-Writes a package.json with `"type": "module"` in ESM output directories, including relocated `overrides`. Package.json files copied into the output also receive this field, preserving other metadata. Existing `.js` and `.d.ts` filenames are retained; Node.js and TypeScript interpret these files as ESM. ESM and CJS must use separate, non-overlapping output directories when this option is enabled.
-
-All three options require explicit configuration. Neither `exports.import` nor the root package.json `type` enables them automatically. Existing configurations retain their build behavior. After disabling an option, perform a default clean build to avoid retaining previously generated files with `clean: false`.
-
-These options do not convert CommonJS dependencies into ESM or make CSS imports and browser-only APIs available in Node.js. See the [native ESM publishing example](./guide/esm-cjs.en-US.md#native-esm-in-nodejs).
+These capabilities require explicit opt-in. Neither `exports.import` nor the root package.json `type` enables them automatically. Existing configurations retain their default build behavior. These options do not convert CommonJS dependencies into ESM or make CSS imports and browser-only APIs available in Node.js. See the [native ESM publishing example](./guide/esm-cjs.en-US.md#native-esm-in-nodejs).
 
 ### **transformer**
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -158,15 +158,36 @@ father 以构建产物类型划分构建配置，其中 `esm`、`cjs` 产物为 
 
 指定产物的输出目录，`esm` 产物的默认输出目录为 `dist/esm`，`cjs` 产物的默认输出目录为 `dist/cjs`。
 
-#### fullySpecified
+#### autoExtension
 
 - 类型：`boolean`
 - 默认值：`false`
-- 仅支持 `esm`，作用于整个 ESM 构建（包括 `overrides`）
+- 支持 `esm`、`cjs` 和 `overrides`
 
-补全相对导入、再导出和字符串字面量 `import()` 的文件后缀或目录入口，例如 `./utils` → `./utils.js` 或 `./utils/index.js`，并同步处理声明文件。根据实际输出位置解析路径，支持移动了输出目录的 `overrides`。无法解析的相对无后缀路径会报错。
+根据 package.json 的包类型和构建格式选择 JavaScript 文件后缀，并同步生成或复制的声明文件后缀：
 
-支持 Babel、esbuild、SWC、并行构建、缓存和 watch，并保留 JS/声明文件 source map。该选项不修改外部依赖路径、产物文件名或 package.json。
+| 包类型                      | ESM 产物          | CJS 产物          |
+| --------------------------- | ----------------- | ----------------- |
+| `type: "module"`            | `.js` / `.d.ts`   | `.cjs` / `.d.cts` |
+| `type: "commonjs"` 或未设置 | `.mjs` / `.d.mts` | `.js` / `.d.ts`   |
+
+后缀选择参考 [Rslib 的 autoExtension](https://rslib.rs/config/lib/auto-extension)。为兼容 Father 4，默认关闭。Father 在开启时同时调整声明文件后缀，避免 `.mjs` 缺少匹配的 `.d.mts` 等类型入口问题。
+
+根 package.json 提供默认包类型；若源码中的 package.json 被复制到输出，则尊重该作用域的包类型，包括通过 `overrides` 移动的输出目录。显式 `.mjs`、`.cjs`、`.d.mts`、`.d.cts` 文件保持原有后缀。不会生成或修改 package.json。
+
+开启后，`redirect.js.extension` 和 `redirect.dts.extension` 默认启用，使文件中的模块引用匹配实际产物。支持 Babel、esbuild、SWC、并行构建、缓存、watch 和 source map。修改包类型、输出配置或关闭选项后，应重新执行一次默认的清理构建，避免 `clean: false` 或已有 watch 进程保留旧文件。
+
+#### redirect
+
+- 类型：`{ js?: { extension?: boolean }; dts?: { extension?: boolean } }`
+- 默认值：两个 `extension` 分别跟随 `autoExtension`，未开启时为 `false`
+- 支持 `esm`、`cjs` 和 `overrides`
+
+借鉴 [Rslib 的 redirect](https://rslib.rs/config/lib/redirect) 配置命名，分别控制 JavaScript 和声明文件中的相对模块引用补全。`js.extension` 处理导入、再导出、字面量 `import()`，以及 CJS 产物中的字面量 `require()`；`dts.extension` 处理声明中的导入、再导出、类型导入及模块扩充。
+
+例如 `./utils` 按实际产物补全为 `./utils.mjs` 或 `./utils/index.mjs`，已有 `./utils.js` 也会同步替换。路径跟随实际输出目录，支持 `overrides`。无法解析的相对无后缀路径会报错。该选项不修改文件本身的后缀或外部依赖路径。
+
+可以只开启 `redirect`，保留 `.js` 文件名并补全内部引用；也可以显式关闭其中一个 `extension`，将对应引用的处理交给消费方的构建工具。
 
 #### resolveDepSubpath
 
@@ -174,19 +195,9 @@ father 以构建产物类型划分构建配置，其中 `esm`、`cjs` 产物为 
 - 默认值：`false`
 - 仅支持 `esm`，作用于整个 ESM 构建（包括 `overrides`）
 
-补全没有 `exports` 的依赖子路径，例如 `dayjs/plugin/weekday` → `dayjs/plugin/weekday.js`。同步处理 JavaScript 与声明文件；包入口、具有 `exports` 的依赖，以及无法解析的依赖保持原有路径。该选项独立于 `fullySpecified`，仅在需要兼容这类旧式依赖时开启。
+补全没有 `exports` 的依赖子路径，例如 `dayjs/plugin/weekday` → `dayjs/plugin/weekday.js`。同步处理 JavaScript 与声明文件；包入口、具有 `exports` 的依赖，以及无法解析的依赖保持原有路径。与 tsdown 的 `deps.resolveDepSubpath` 类似，独立于内部引用补全，仅在需要兼容这类旧式依赖时开启。
 
-#### outputPackageType
-
-- 类型：`'module'`
-- 默认值：`undefined`（不生成或修改包元数据）
-- 仅支持 `esm`，作用于整个 ESM 构建（包括 `overrides`）
-
-在 ESM 输出目录（包括 `overrides` 的输出目录）生成包含 `"type": "module"` 的 package.json；复制到输出目录中的 package.json 也会设置此字段，其他字段保持不变。保留既有 `.js` 和 `.d.ts` 文件名，让 Node.js 和 TypeScript 将该目录内的文件按 ESM 解释。启用时，ESM 和 CJS 必须使用互不包含的独立输出目录。
-
-这三个选项均需显式配置，`exports.import` 和根 package.json 的 `type` 不会自动启用它们。不修改现有配置时，原有构建行为保持不变。关闭选项后应执行一次默认的清理构建，避免 `clean: false` 留下先前生成的文件。
-
-这些选项不会将 CommonJS 依赖转换为 ESM，也不会使 CSS 导入或浏览器专用 API 获得 Node.js 支持。完整双格式发布示例见[构建 ESModule 与 CommonJS 产物](./guide/esm-cjs.md#nodejs-原生-esm)。
+以上能力均需显式开启，`exports.import` 和根 package.json 的 `type` 不会自动启用它们。现有配置的默认构建行为不变。这些选项不会将 CommonJS 依赖转换为 ESM，也不会使 CSS 导入或浏览器专用 API 获得 Node.js 支持。完整发布示例见[构建 ESModule 与 CommonJS 产物](./guide/esm-cjs.md#nodejs-原生-esm)。
 
 #### transformer
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -158,6 +158,36 @@ father 以构建产物类型划分构建配置，其中 `esm`、`cjs` 产物为 
 
 指定产物的输出目录，`esm` 产物的默认输出目录为 `dist/esm`，`cjs` 产物的默认输出目录为 `dist/cjs`。
 
+#### fullySpecified
+
+- 类型：`boolean`
+- 默认值：`false`
+- 仅支持 `esm`，作用于整个 ESM 构建（包括 `overrides`）
+
+补全相对导入、再导出和字符串字面量 `import()` 的文件后缀或目录入口，例如 `./utils` → `./utils.js` 或 `./utils/index.js`，并同步处理声明文件。根据实际输出位置解析路径，支持移动了输出目录的 `overrides`。无法解析的相对无后缀路径会报错。
+
+支持 Babel、esbuild、SWC、并行构建、缓存和 watch，并保留 JS/声明文件 source map。该选项不修改外部依赖路径、产物文件名或 package.json。
+
+#### resolveDepSubpath
+
+- 类型：`boolean`
+- 默认值：`false`
+- 仅支持 `esm`，作用于整个 ESM 构建（包括 `overrides`）
+
+补全没有 `exports` 的依赖子路径，例如 `dayjs/plugin/weekday` → `dayjs/plugin/weekday.js`。同步处理 JavaScript 与声明文件；包入口、具有 `exports` 的依赖，以及无法解析的依赖保持原有路径。该选项独立于 `fullySpecified`，仅在需要兼容这类旧式依赖时开启。
+
+#### outputPackageType
+
+- 类型：`'module'`
+- 默认值：`undefined`（不生成或修改包元数据）
+- 仅支持 `esm`，作用于整个 ESM 构建（包括 `overrides`）
+
+在 ESM 输出目录（包括 `overrides` 的输出目录）生成包含 `"type": "module"` 的 package.json；复制到输出目录中的 package.json 也会设置此字段，其他字段保持不变。保留既有 `.js` 和 `.d.ts` 文件名，让 Node.js 和 TypeScript 将该目录内的文件按 ESM 解释。启用时，ESM 和 CJS 必须使用互不包含的独立输出目录。
+
+这三个选项均需显式配置，`exports.import` 和根 package.json 的 `type` 不会自动启用它们。不修改现有配置时，原有构建行为保持不变。关闭选项后应执行一次默认的清理构建，避免 `clean: false` 留下先前生成的文件。
+
+这些选项不会将 CommonJS 依赖转换为 ESM，也不会使 CSS 导入或浏览器专用 API 获得 Node.js 支持。完整双格式发布示例见[构建 ESModule 与 CommonJS 产物](./guide/esm-cjs.md#nodejs-原生-esm)。
+
 #### transformer
 
 - 类型：`babel` | `esbuild` | `swc`

--- a/docs/guide/esm-cjs.en-US.md
+++ b/docs/guide/esm-cjs.en-US.md
@@ -1,25 +1,25 @@
-# Building ESModule and CommonJS Outputs  
+# Building ESModule and CommonJS Outputs
 
-> In the Father project, ESModule and CommonJS output builds follow a similar process, so they are covered together in this chapter.  
+> In the Father project, ESModule and CommonJS output builds follow a similar process, so they are covered together in this chapter.
 
-## How to Choose  
+## How to Choose
 
-ESModule is the module standard for JavaScript, while CommonJS is used by Node.js. To determine which output format your project needs, consider the usage scenario:  
+Node.js supports both ESModule and CommonJS, while browsers and frontend bundlers primarily use ESModule. Choose the output format according to your consumers:
 
-| Output Type / Runtime | Browser | Node.js  | Both    |
-| ---------------------- | ------- | -------- | ------- |
-| ESModule              | ✅ Recommended | Not Recommended Yet | ✅ Recommended |
-| CommonJS              | Not Necessary  | ✅ Recommended  | ✅ Recommended |  
+| Output Type / Runtime | Browser        | Node.js        | Both           |
+| --------------------- | -------------- | -------------- | -------------- |
+| ESModule              | ✅ Recommended | ✅ Supported   | ✅ Recommended |
+| CommonJS              | Not Necessary  | ✅ Recommended | ✅ Recommended |
 
-Additional Notes  
+Additional Notes
 
-1. The push for Pure ESM in the Node.js community still faces [some challenges](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c). For broader compatibility, it is still recommended to produce CommonJS outputs for Node.js projects. In the future, Father will introduce a compatibility solution for generating both ESModule and CommonJS outputs.  
-2. For browser environments, CommonJS output is unnecessary since all modern module bundlers can handle ESModules. With the rise of tools like Vite that support native ESModules, using ESModule is the best future-proof approach.  
-3. Both means the output is intended for use in both browser and Node.js environments, such as `react-dom` and `umi`.  
+1. When publishing ESModule for Node.js, use the native ESM configuration below. To support CommonJS consumers too, generate CJS output and select the entry points with conditional exports.
+2. For browser environments, CommonJS output is unnecessary since all modern module bundlers can handle ESModules. With the rise of tools like Vite that support native ESModules, using ESModule is the best future-proof approach.
+3. Both means the output is intended for use in both browser and Node.js environments, such as `react-dom` and `umi`.
 
-## How to Build  
+## How to Build
 
-Use the `esm` and `cjs` configuration options, then run `father build` to generate ESModule and CommonJS outputs:  
+Use the `esm` and `cjs` configuration options, then run `father build` to generate ESModule and CommonJS outputs:
 
 ```js
 // .fatherrc.js
@@ -37,8 +37,56 @@ export default {
     transformer: 'esbuild', // Uses esbuild for faster build speeds
   },
 };
-```  
+```
 
-For more configuration options, refer to the [Configuration Guide](../config.md).  
+For more configuration options, refer to the [Configuration Guide](../config.md).
 
-In the Father project, both ESModule and CommonJS outputs are built using the Bundless mode. For details on Bundless mode, see [Build Modes - Bundless](./build-mode.md#bundless).  
+## Native ESM in Node.js
+
+The traditional `module` field is intended for bundlers and does not guarantee that Node.js can load its paths directly. Father can complete ESM specifiers, align declarations, and generate an ESM package marker:
+
+```ts
+// .fatherrc.ts
+export default {
+  esm: {
+    output: 'es',
+    platform: 'node',
+    fullySpecified: true,
+    outputPackageType: 'module',
+  },
+  cjs: { output: 'lib' },
+};
+```
+
+Declare separate runtime and type entry points in `package.json`:
+
+```json
+{
+  "main": "./lib/index.js",
+  "module": "./es/index.js",
+  "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./es/index.d.ts",
+        "default": "./es/index.js"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      }
+    }
+  },
+  "files": ["es", "lib"]
+}
+```
+
+Configure these options explicitly: `exports.import` declares consumer entry points and does not enable build options. TypeScript projects also need `declaration` enabled in `tsconfig.json`. Publish the generated `es/package.json`. Keep the root package in CommonJS mode so `.js` and `.d.ts` files in `lib` are interpreted as CommonJS.
+
+`fullySpecified` changes `export * from './utils'` to `export * from './utils.js'` or `export * from './utils/index.js'`, depending on the actual output, and aligns declaration specifiers. `outputPackageType` controls package markers independently; omit it when the package type is already set correctly. Neither option changes output filenames.
+
+External dependency paths are preserved by default. For legacy subpaths such as `dayjs/plugin/weekday` in packages without `exports`, enable `esm.resolveDepSubpath: true` separately. Dependencies with `exports` always keep their public specifiers.
+
+Existing `esm: {}` builds retain their behavior: all these options are disabled by default. Father already preserves ESM syntax, and its output can run directly in Node.js when source paths and package types meet Node.js requirements. These options automate path completion and package markers; your code and dependencies must still support Node.js.
+
+In the Father project, both ESModule and CommonJS outputs are built using the Bundless mode. For details on Bundless mode, see [Build Modes - Bundless](./build-mode.md#bundless).

--- a/docs/guide/esm-cjs.en-US.md
+++ b/docs/guide/esm-cjs.en-US.md
@@ -43,7 +43,7 @@ For more configuration options, refer to the [Configuration Guide](../config.md)
 
 ## Native ESM in Node.js
 
-The traditional `module` field is intended for bundlers and does not guarantee that Node.js can load its paths directly. Father can complete ESM specifiers, align declarations, and generate an ESM package marker:
+The traditional `module` field is intended for bundlers and does not guarantee that Node.js can load its paths directly. Father can choose output extensions according to package types and align module references and declarations:
 
 ```ts
 // .fatherrc.ts
@@ -51,10 +51,9 @@ export default {
   esm: {
     output: 'es',
     platform: 'node',
-    fullySpecified: true,
-    outputPackageType: 'module',
+    autoExtension: true,
   },
-  cjs: { output: 'lib' },
+  cjs: { output: 'lib', autoExtension: true },
 };
 ```
 
@@ -62,14 +61,15 @@ Declare separate runtime and type entry points in `package.json`:
 
 ```json
 {
+  "type": "commonjs",
   "main": "./lib/index.js",
-  "module": "./es/index.js",
+  "module": "./es/index.mjs",
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
       "import": {
-        "types": "./es/index.d.ts",
-        "default": "./es/index.js"
+        "types": "./es/index.d.mts",
+        "default": "./es/index.mjs"
       },
       "require": {
         "types": "./lib/index.d.ts",
@@ -81,12 +81,12 @@ Declare separate runtime and type entry points in `package.json`:
 }
 ```
 
-Configure these options explicitly: `exports.import` declares consumer entry points and does not enable build options. TypeScript projects also need `declaration` enabled in `tsconfig.json`. Publish the generated `es/package.json`. Keep the root package in CommonJS mode so `.js` and `.d.ts` files in `lib` are interpreted as CommonJS.
+This example explicitly uses a CommonJS root package, producing `.mjs` / `.d.mts` for ESM and `.js` / `.d.ts` for CJS. With `"type": "module"`, these become `.js` / `.d.ts` and `.cjs` / `.d.cts` respectively; update the published entry points accordingly. Father does not generate additional package.json files or modify root package metadata.
 
-`fullySpecified` changes `export * from './utils'` to `export * from './utils.js'` or `export * from './utils/index.js'`, depending on the actual output, and aligns declaration specifiers. `outputPackageType` controls package markers independently; omit it when the package type is already set correctly. Neither option changes output filenames.
+Enable `autoExtension` explicitly; `exports.import` only declares consumer entry points. TypeScript projects also need `declaration` enabled in `tsconfig.json`. Relative imports, re-exports, dynamic imports and CJS `require()` references follow actual output files by default, as do declaration references. Control them independently with `redirect.js.extension` and `redirect.dts.extension`.
 
-External dependency paths are preserved by default. For legacy subpaths such as `dayjs/plugin/weekday` in packages without `exports`, enable `esm.resolveDepSubpath: true` separately. Dependencies with `exports` always keep their public specifiers.
+External dependency paths are preserved by default. For legacy subpaths such as `dayjs/plugin/weekday` in packages without `exports`, enable `esm.resolveDepSubpath: true` separately. Dependencies with `exports` retain their public specifiers.
 
-Existing `esm: {}` builds retain their behavior: all these options are disabled by default. Father already preserves ESM syntax, and its output can run directly in Node.js when source paths and package types meet Node.js requirements. These options automate path completion and package markers; your code and dependencies must still support Node.js.
+Existing `esm: {}` / `cjs: {}` builds retain their behavior. Father already preserves ESM syntax, and its output can run directly in Node.js when source paths and package types meet Node.js requirements. The new options automate output extensions and references; your code and dependencies must still support Node.js.
 
 In the Father project, both ESModule and CommonJS outputs are built using the Bundless mode. For details on Bundless mode, see [Build Modes - Bundless](./build-mode.md#bundless).

--- a/docs/guide/esm-cjs.md
+++ b/docs/guide/esm-cjs.md
@@ -43,7 +43,7 @@ export default {
 
 ## Node.js 原生 ESM
 
-传统 `module` 字段供打包工具使用，并不保证其中的路径能被 Node.js 直接加载。father 可以补全 ESM 产物中的路径、同步声明文件，并生成 ESM 包类型标记：
+传统 `module` 字段供打包工具使用，并不保证其中的路径能被 Node.js 直接加载。father 可以按包类型选择产物后缀，并同步补全模块引用和声明文件：
 
 ```ts
 // .fatherrc.ts
@@ -51,10 +51,9 @@ export default {
   esm: {
     output: 'es',
     platform: 'node',
-    fullySpecified: true,
-    outputPackageType: 'module',
+    autoExtension: true,
   },
-  cjs: { output: 'lib' },
+  cjs: { output: 'lib', autoExtension: true },
 };
 ```
 
@@ -62,14 +61,15 @@ export default {
 
 ```json
 {
+  "type": "commonjs",
   "main": "./lib/index.js",
-  "module": "./es/index.js",
+  "module": "./es/index.mjs",
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
       "import": {
-        "types": "./es/index.d.ts",
-        "default": "./es/index.js"
+        "types": "./es/index.d.mts",
+        "default": "./es/index.mjs"
       },
       "require": {
         "types": "./lib/index.d.ts",
@@ -81,12 +81,12 @@ export default {
 }
 ```
 
-上述选项必须显式配置：`exports.import` 只声明消费入口，不会启用构建选项。TypeScript 项目还需在 `tsconfig.json` 开启 `declaration`。发布时包含生成的 `es/package.json`；根 package.json 保持 CommonJS 包类型，使 `lib` 中的 `.js` 和 `.d.ts` 按 CommonJS 解释。
+这个例子明确使用 CommonJS 根包，因此 ESM 产物为 `.mjs` / `.d.mts`，CJS 产物为 `.js` / `.d.ts`。若改为 `"type": "module"`，则分别变为 `.js` / `.d.ts` 与 `.cjs` / `.d.cts`，需要同步更新发布入口。Father 不会生成额外的 package.json，也不会修改根包元数据。
 
-`fullySpecified` 将 `export * from './utils'` 按实际产物补全为 `export * from './utils.js'` 或 `export * from './utils/index.js'`，声明文件中的路径同步补全。`outputPackageType` 单独控制包类型标记；如果包类型已经正确设置，可以省略它。两者均不改变产物文件名。
+`autoExtension` 必须显式开启，`exports.import` 只声明消费入口。TypeScript 项目还需在 `tsconfig.json` 开启 `declaration`。产物中的相对导入、再导出、动态导入和 CJS `require()` 默认同步指向实际文件，声明中的路径也会补全；可用 `redirect.js.extension` 和 `redirect.dts.extension` 分别控制。
 
 外部依赖路径默认保持原样。如果依赖使用 `dayjs/plugin/weekday` 这类没有 `exports` 的子路径，可以额外设置 `esm.resolveDepSubpath: true`。具有 `exports` 的依赖始终保留公共导入路径。
 
-已有的 `esm: {}` 构建行为保持不变，以上选项默认都不启用。原有 `esm` 已能保留 ESM 语法；当源码路径和包类型符合要求时，也能直接被 Node.js 加载。这些选项提供自动补全和包类型标记，应用代码及依赖仍需适用于 Node.js。
+已有的 `esm: {}` / `cjs: {}` 构建行为保持不变。原有 `esm` 已能保留 ESM 语法，当源码路径和包类型符合要求时也能直接被 Node.js 加载。新选项自动处理产物后缀和路径，应用代码及依赖仍需适用于 Node.js。
 
 在 father 项目中，ESModule 产物及 CommonJS 产物都以 Bundless 模式进行构建，关于 Bundless 模式的介绍可参考 [构建模式 - Bundless](./build-mode.md#bundless)。

--- a/docs/guide/esm-cjs.md
+++ b/docs/guide/esm-cjs.md
@@ -4,16 +4,16 @@
 
 ## 如何选择
 
-ESModule 是 JavaScript 使用的模块规范，而 CommonJS 是 Node.js 使用的模块规范，这我们已经很熟悉了，所以我们的项目需要输出什么产物，只需要根据使用情况判断即可：
+Node.js 支持 ESModule 和 CommonJS，浏览器及前端构建工具主要使用 ESModule。可以根据消费方选择产物：
 
-| 产物类型/运行环境 | Browser | Node.js  | Both    |
-| ----------------- | ------- | -------- | ------- |
-| ESModule          | ✅ 推荐 | 暂不推荐 | ✅ 推荐 |
-| CommonJS          | 没必要  | ✅ 推荐  | ✅ 推荐 |
+| 产物类型/运行环境 | Browser | Node.js | Both    |
+| ----------------- | ------- | ------- | ------- |
+| ESModule          | ✅ 推荐 | ✅ 支持 | ✅ 推荐 |
+| CommonJS          | 没必要  | ✅ 推荐 | ✅ 推荐 |
 
 额外说明：
 
-1. 由于 Node.js 社区的 Pure ESM 推进[仍有阻碍](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c)，所以为了通用性考虑，目前仍然建议大家为 Node.js 项目产出 CommonJS 产物，未来 father 也会推出同时产出 ESModule 产物的兼容方案，敬请期待
+1. 为 Node.js 发布 ESModule 时，使用下文的原生 ESM 配置；需要兼容 CommonJS 消费方时，可以同时产出 CJS，并使用条件导出区分入口。
 2. 对于 Browser 运行环境，CommonJS 产物是没必要的，无论哪种模块构建工具都能帮我们解析，加上 Vite 这类使用原生 ESModule 产物的构建工具已经成熟，使用 ESModule 才是面向未来的最佳选择
 3. Both 是指构建产物要同时用于 Browser 和 Node.js 的项目，比如 react-dom、umi 等
 
@@ -40,5 +40,53 @@ export default {
 ```
 
 更多配置项可参考 [配置项](../config.md)。
+
+## Node.js 原生 ESM
+
+传统 `module` 字段供打包工具使用，并不保证其中的路径能被 Node.js 直接加载。father 可以补全 ESM 产物中的路径、同步声明文件，并生成 ESM 包类型标记：
+
+```ts
+// .fatherrc.ts
+export default {
+  esm: {
+    output: 'es',
+    platform: 'node',
+    fullySpecified: true,
+    outputPackageType: 'module',
+  },
+  cjs: { output: 'lib' },
+};
+```
+
+在 `package.json` 中分别声明两个入口及类型入口：
+
+```json
+{
+  "main": "./lib/index.js",
+  "module": "./es/index.js",
+  "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./es/index.d.ts",
+        "default": "./es/index.js"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      }
+    }
+  },
+  "files": ["es", "lib"]
+}
+```
+
+上述选项必须显式配置：`exports.import` 只声明消费入口，不会启用构建选项。TypeScript 项目还需在 `tsconfig.json` 开启 `declaration`。发布时包含生成的 `es/package.json`；根 package.json 保持 CommonJS 包类型，使 `lib` 中的 `.js` 和 `.d.ts` 按 CommonJS 解释。
+
+`fullySpecified` 将 `export * from './utils'` 按实际产物补全为 `export * from './utils.js'` 或 `export * from './utils/index.js'`，声明文件中的路径同步补全。`outputPackageType` 单独控制包类型标记；如果包类型已经正确设置，可以省略它。两者均不改变产物文件名。
+
+外部依赖路径默认保持原样。如果依赖使用 `dayjs/plugin/weekday` 这类没有 `exports` 的子路径，可以额外设置 `esm.resolveDepSubpath: true`。具有 `exports` 的依赖始终保留公共导入路径。
+
+已有的 `esm: {}` 构建行为保持不变，以上选项默认都不启用。原有 `esm` 已能保留 ESM 语法；当源码路径和包类型符合要求时，也能直接被 Node.js 加载。这些选项提供自动补全和包类型标记，应用代码及依赖仍需适用于 Node.js。
 
 在 father 项目中，ESModule 产物及 CommonJS 产物都以 Bundless 模式进行构建，关于 Bundless 模式的介绍可参考 [构建模式 - Bundless](./build-mode.md#bundless)。

--- a/src/builder/bundless/esm.ts
+++ b/src/builder/bundless/esm.ts
@@ -1,0 +1,278 @@
+import { MagicString, remapping, winPath } from '@umijs/utils';
+import fs from 'fs';
+import { createRequire } from 'module';
+import path from 'path';
+import type { BundlessConfigProvider, IBundlessConfig } from '../config';
+
+function isFile(file: string) {
+  return fs.existsSync(file) && fs.statSync(file).isFile();
+}
+
+export function getRuntimePath(file: string) {
+  return file
+    .replace(/\.d\.mts$/, '.mjs')
+    .replace(/\.d\.cts$/, '.cjs')
+    .replace(/\.d\.ts$/, '.js')
+    .replace(/\.(tsx?|jsx)$/, '.js');
+}
+
+const runtimeExtensions = ['.js', '.mjs', '.cjs'];
+const declarationExtensions = ['.d.ts', '.d.mts', '.d.cts'];
+
+function findFile(file: string, extensions: string[]) {
+  return [
+    file,
+    ...extensions.map((ext) => `${file}${ext}`),
+    ...extensions.map((ext) => path.join(file, `index${ext}`)),
+  ].find(isFile);
+}
+
+function resolvePackageSpecifier(file: string, specifier: string) {
+  // Package roots, imports maps, URLs and builtins already have Node semantics.
+  if (/^(?:[a-zA-Z][\w+.-]*:|#|\/)/.test(specifier)) return specifier;
+  const parts = specifier.split('/');
+  const name = parts.slice(0, specifier.startsWith('@') ? 2 : 1).join('/');
+  if (name === specifier) return specifier;
+
+  try {
+    const requireFromFile = createRequire(file);
+    const packageFile = requireFromFile.resolve(`${name}/package.json`);
+    const pkg = JSON.parse(fs.readFileSync(packageFile, 'utf-8'));
+    // Do not use require conditions to rewrite packages with an exports map.
+    if (Object.prototype.hasOwnProperty.call(pkg, 'exports')) return specifier;
+    const resolved = requireFromFile.resolve(specifier);
+    const relative = winPath(
+      path.relative(path.dirname(packageFile), resolved),
+    );
+    if (
+      !relative.startsWith('../') &&
+      !path.isAbsolute(relative) &&
+      runtimeExtensions.includes(path.extname(relative))
+    ) {
+      return `${name}/${relative}`;
+    }
+  } catch {
+    // Optional dependencies and packages hiding package.json are left intact.
+  }
+  return specifier;
+}
+
+interface IOutputFile {
+  file: string;
+  sourceFile: string;
+}
+
+function resolveRelativeSpecifier(
+  specifier: string,
+  output: IOutputFile,
+  cwd: string,
+  provider: BundlessConfigProvider,
+) {
+  const suffixIndex = specifier.search(/[?#]/);
+  const request = suffixIndex < 0 ? specifier : specifier.slice(0, suffixIndex);
+  const suffix = suffixIndex < 0 ? '' : specifier.slice(suffixIndex);
+  const isDeclaration = /\.d\.[cm]?ts$/.test(output.file);
+  const extensions = isDeclaration
+    ? [...runtimeExtensions, ...declarationExtensions]
+    : runtimeExtensions;
+
+  // Resolve against sources first so overrides with relocated outputs also work.
+  const sourceRequest = path.resolve(path.dirname(output.sourceFile), request);
+  const sourceExtensions = [
+    '.ts',
+    '.tsx',
+    '.js',
+    '.jsx',
+    '.mjs',
+    '.cjs',
+    ...declarationExtensions,
+  ];
+  const source =
+    findFile(sourceRequest, sourceExtensions) ||
+    (/\.js$/.test(request)
+      ? findFile(sourceRequest.slice(0, -3), sourceExtensions)
+      : undefined);
+  let target: string | undefined;
+  if (source) {
+    const config = provider.getConfigForFile(
+      winPath(path.relative(cwd, source)),
+    );
+    if (config) {
+      const emitted = path.resolve(
+        cwd,
+        config.output,
+        path.relative(config.input, path.relative(cwd, source)),
+      );
+      const runtime = getRuntimePath(emitted);
+      if (isFile(runtime) || (isDeclaration && isFile(emitted))) {
+        target = runtime;
+      }
+    }
+  }
+  target ||= findFile(
+    path.resolve(path.dirname(output.file), request),
+    extensions,
+  );
+  if (target) {
+    const relative = winPath(
+      path.relative(path.dirname(output.file), getRuntimePath(target)),
+    );
+    return `${
+      relative.startsWith('../') ? relative : `./${relative}`
+    }${suffix}`;
+  }
+  if (path.extname(request)) return specifier;
+  throw new Error(
+    `Cannot resolve fully specified ESM import ${JSON.stringify(
+      specifier,
+    )} from ${path.relative(cwd, output.file)}`,
+  );
+}
+
+function rewriteOutput(
+  output: IOutputFile,
+  cwd: string,
+  provider: BundlessConfigProvider,
+  config: IBundlessConfig,
+) {
+  // Load the parser only when ESM import rewriting is enabled.
+  const ts: typeof import('typescript') = require('typescript');
+  const content = fs.readFileSync(output.file, 'utf-8');
+  const source = ts.createSourceFile(
+    output.file,
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const result = new MagicString(content);
+  let changed = false;
+  const replace = (node: import('typescript').Node | undefined) => {
+    if (!node || !ts.isStringLiteralLike(node)) return;
+    const specifier = node.text;
+    const isRelative = /^(?:\.\.?\/|\.\.?$)/.test(specifier);
+    const replacement = isRelative
+      ? config.fullySpecified
+        ? resolveRelativeSpecifier(specifier, output, cwd, provider)
+        : specifier
+      : config.resolveDepSubpath
+      ? resolvePackageSpecifier(output.file, specifier)
+      : specifier;
+    if (replacement !== specifier) {
+      result.overwrite(
+        node.getStart(source),
+        node.end,
+        JSON.stringify(replacement),
+      );
+      changed = true;
+    }
+  };
+  const visit = (node: import('typescript').Node) => {
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      replace(node.moduleSpecifier);
+    } else if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword
+    ) {
+      replace(node.arguments[0]);
+    } else if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument)
+    ) {
+      replace(node.argument.literal);
+    } else if (source.isDeclarationFile && ts.isModuleDeclaration(node)) {
+      // Relative module augmentations must refer to the same fully specified module.
+      if (ts.isStringLiteral(node.name) && node.name.text.startsWith('.'))
+        replace(node.name);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  if (!changed) return;
+
+  // Compose the edits with JS/declaration maps instead of invalidating columns.
+  const mapFile = `${output.file}.map`;
+  if (isFile(mapFile)) {
+    const originalMap = JSON.parse(fs.readFileSync(mapFile, 'utf-8'));
+    const editMap = result.generateMap({
+      hires: true,
+      source: path.basename(output.file),
+    });
+    const map = remapping([editMap, originalMap], () => null);
+    map.file = originalMap.file;
+    fs.writeFileSync(mapFile, JSON.stringify(map));
+  }
+  fs.writeFileSync(output.file, result.toString());
+}
+
+export function finalizeEsm(
+  outputs: IOutputFile[],
+  cwd: string,
+  provider: BundlessConfigProvider,
+) {
+  if (
+    !provider.configs.some(
+      (config) =>
+        config.fullySpecified ||
+        config.resolveDepSubpath ||
+        config.outputPackageType,
+    )
+  )
+    return;
+  const enabledOutputs = outputs.map((output) => ({
+    ...output,
+    config: provider.getConfigForFile(
+      winPath(path.relative(cwd, output.sourceFile)),
+    ),
+  }));
+  // tsc emits maps relative to its declaration location; Father relocates
+  // declarations to the configured output (possibly an override directory).
+  for (const output of enabledOutputs) {
+    if (
+      output.config?.fullySpecified &&
+      /\.d\.[cm]?ts\.map$/.test(output.file) &&
+      isFile(output.file)
+    ) {
+      const map = JSON.parse(fs.readFileSync(output.file, 'utf-8'));
+      if (!map.sourceRoot) {
+        map.sources = [
+          winPath(path.relative(path.dirname(output.file), output.sourceFile)),
+        ];
+        fs.writeFileSync(output.file, JSON.stringify(map));
+      }
+    }
+  }
+  for (const output of enabledOutputs) {
+    const config = output.config;
+    if (
+      (config?.fullySpecified || config?.resolveDepSubpath) &&
+      /(?:\.m?js|\.d\.[cm]?ts)$/.test(output.file) &&
+      isFile(output.file)
+    ) {
+      rewriteOutput(output, cwd, provider, config);
+    }
+  }
+  // A package marker is independent of import rewriting. Include relocated
+  // overrides and copied package scopes while preserving their other metadata.
+  const packageFiles = new Set(
+    provider.configs
+      .filter((config) => config.outputPackageType === 'module')
+      .map((config) => path.resolve(cwd, config.output, 'package.json')),
+  );
+  enabledOutputs
+    .filter(
+      (output) =>
+        output.config?.outputPackageType === 'module' &&
+        path.basename(output.file) === 'package.json',
+    )
+    .forEach((output) => packageFiles.add(output.file));
+  for (const file of packageFiles) {
+    const pkg = isFile(file) ? JSON.parse(fs.readFileSync(file, 'utf-8')) : {};
+    if (pkg.type !== 'module') {
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(
+        file,
+        `${JSON.stringify({ ...pkg, type: 'module' }, null, 2)}\n`,
+      );
+    }
+  }
+}

--- a/src/builder/bundless/index.ts
+++ b/src/builder/bundless/index.ts
@@ -9,6 +9,7 @@ import {
 import { logger } from '../../utils';
 import type { BundlessConfigProvider } from '../config';
 import getDeclarations from './dts';
+import { finalizeEsm, getRuntimePath } from './esm';
 import type { IDeclarationResult, ILoaderArgs } from './loaders';
 import runLoaders from './loaders';
 import { IJSTransformer, IJSTransformerFn } from './loaders/types';
@@ -94,6 +95,7 @@ async function transformFiles(
 ) {
   try {
     let count = 0;
+    const outputs: { file: string; sourceFile: string }[] = [];
     let bundlessPromises = [];
     let declarationFileMap = new Map<
       string,
@@ -114,6 +116,12 @@ async function transformFiles(
           path.relative(config.input, item),
         );
         let itemDistAbsPath = path.join(opts.cwd, itemDistPath);
+        outputs.push({
+          file: /\.d\.[cm]?ts$/.test(itemDistAbsPath)
+            ? itemDistAbsPath
+            : getRuntimePath(itemDistAbsPath),
+          sourceFile: itemAbsPath,
+        });
         const parentPath = path.dirname(itemDistAbsPath);
 
         // create parent directory if not exists
@@ -181,14 +189,15 @@ async function transformFiles(
         );
 
         declarations.forEach((item) => {
-          fs.writeFileSync(
-            path.join(outputDirs.get(item.sourceFile)!, item.file),
-            item.content,
-            'utf-8',
-          );
+          const file = path.join(outputDirs.get(item.sourceFile)!, item.file);
+          fs.writeFileSync(file, item.content, 'utf-8');
+          outputs.push({ file, sourceFile: item.sourceFile });
         });
       }
     }
+
+    // Run after all JS, assets and declarations exist, including cache hits.
+    finalizeEsm(outputs, opts.cwd, opts.configProvider);
 
     return count;
   } catch (err: any) {

--- a/src/builder/bundless/index.ts
+++ b/src/builder/bundless/index.ts
@@ -1,4 +1,12 @@
-import { chalk, chokidar, debug, glob, lodash, rimraf } from '@umijs/utils';
+import {
+  chalk,
+  chokidar,
+  debug,
+  glob,
+  lodash,
+  rimraf,
+  winPath,
+} from '@umijs/utils';
 import fs from 'fs';
 import path from 'path';
 import {
@@ -9,10 +17,15 @@ import {
 import { logger } from '../../utils';
 import type { BundlessConfigProvider } from '../config';
 import getDeclarations from './dts';
-import { finalizeEsm, getRuntimePath } from './esm';
 import type { IDeclarationResult, ILoaderArgs } from './loaders';
 import runLoaders from './loaders';
 import { IJSTransformer, IJSTransformerFn } from './loaders/types';
+import {
+  finalizeOutputs,
+  getDeclarationFile,
+  getOutputFile,
+  getRuntimePath,
+} from './output';
 import createParallelLoader from './parallelLoader';
 
 const debugLog = debug(DEBUG_BUNDLESS_NAME);
@@ -115,7 +128,11 @@ async function transformFiles(
           config.output!,
           path.relative(config.input, item),
         );
-        let itemDistAbsPath = path.join(opts.cwd, itemDistPath);
+        let itemDistAbsPath = config.autoExtension
+          ? getOutputFile(itemAbsPath, opts.cwd, opts.configProvider)
+          : path.join(opts.cwd, itemDistPath);
+        if (config.autoExtension)
+          itemDistPath = path.relative(opts.cwd, itemDistAbsPath);
         outputs.push({
           file: /\.d\.[cm]?ts$/.test(itemDistAbsPath)
             ? itemDistAbsPath
@@ -189,7 +206,16 @@ async function transformFiles(
         );
 
         declarations.forEach((item) => {
-          const file = path.join(outputDirs.get(item.sourceFile)!, item.file);
+          const config = opts.configProvider.getConfigForFile(
+            winPath(path.relative(opts.cwd, item.sourceFile)),
+          )!;
+          const filename = config.autoExtension
+            ? getDeclarationFile(
+                item.file,
+                getOutputFile(item.sourceFile, opts.cwd, opts.configProvider),
+              )
+            : item.file;
+          const file = path.join(outputDirs.get(item.sourceFile)!, filename);
           fs.writeFileSync(file, item.content, 'utf-8');
           outputs.push({ file, sourceFile: item.sourceFile });
         });
@@ -197,7 +223,7 @@ async function transformFiles(
     }
 
     // Run after all JS, assets and declarations exist, including cache hits.
-    finalizeEsm(outputs, opts.cwd, opts.configProvider);
+    finalizeOutputs(outputs, opts.cwd, opts.configProvider);
 
     return count;
   } catch (err: any) {
@@ -294,7 +320,29 @@ async function bundless(
             path.relative(config.input, rltFilePath),
           );
           // TODO: collect real emit files
-          const relatedFiles = isTsFile
+          const emitted = getOutputFile(
+            path.resolve(opts.cwd, rltFilePath),
+            opts.cwd,
+            opts.configProvider,
+          );
+          const relatedFiles = config.autoExtension
+            ? [
+                emitted,
+                `${emitted}.map`,
+                ...(isTsFile && !/\.d\.ts$/.test(rltFilePath)
+                  ? [
+                      getDeclarationFile(
+                        replacePathExt(emitted, '.d.ts'),
+                        emitted,
+                      ),
+                      getDeclarationFile(
+                        replacePathExt(emitted, '.d.ts.map'),
+                        emitted,
+                      ),
+                    ]
+                  : []),
+              ]
+            : isTsFile
             ? [
                 replacePathExt(fileDistAbsPath, '.js'),
                 replacePathExt(fileDistAbsPath, '.d.ts'),

--- a/src/builder/bundless/loaders/index.ts
+++ b/src/builder/bundless/loaders/index.ts
@@ -84,6 +84,7 @@ export default async (args: ILoaderArgs) => {
   // format: {path:contenthash:config:pkgDeps}
   const cacheKey = [
     args.fileAbsPath,
+    ...(args.opts.config.autoExtension ? [args.opts.itemDistAbsPath] : []),
     getContentHash(fs.readFileSync(args.fileAbsPath, 'utf-8')),
     JSON.stringify(args.opts.config),
     // use for babel opts generator in src/builder/utils.ts

--- a/src/builder/bundless/loaders/javascript/index.ts
+++ b/src/builder/bundless/loaders/javascript/index.ts
@@ -1,4 +1,5 @@
 import { winPath } from '@umijs/utils';
+import path from 'path';
 import { getTsconfig } from '../../dts';
 import type { IBundlessLoader, IJSTransformer, ILoaderOutput } from '../types';
 
@@ -35,6 +36,9 @@ const jsLoader: IBundlessLoader = function (content) {
   if (/\.(jsx|tsx?)$/.test(this.resource)) {
     outputOpts.ext = '.js';
   }
+
+  if (this.config.autoExtension)
+    outputOpts.ext = path.extname(this.itemDistAbsPath);
 
   // mark for output declaration file
   const tsconfig = /\.tsx?$/.test(this.resource)

--- a/src/builder/bundless/output.ts
+++ b/src/builder/bundless/output.ts
@@ -2,6 +2,7 @@ import { MagicString, remapping, winPath } from '@umijs/utils';
 import fs from 'fs';
 import { createRequire } from 'module';
 import path from 'path';
+import { IFatherBundlessTypes } from '../../types';
 import type { BundlessConfigProvider, IBundlessConfig } from '../config';
 
 function isFile(file: string) {
@@ -14,6 +15,85 @@ export function getRuntimePath(file: string) {
     .replace(/\.d\.cts$/, '.cjs')
     .replace(/\.d\.ts$/, '.js')
     .replace(/\.(tsx?|jsx)$/, '.js');
+}
+
+// Resolve package scopes that will be copied, even before the assets are emitted.
+// Reading mapped source metadata also keeps relocated overrides consistent.
+function getPackageType(
+  file: string,
+  cwd: string,
+  provider: BundlessConfigProvider,
+) {
+  let dir = path.dirname(file);
+  while (dir !== cwd && dir !== path.dirname(dir)) {
+    for (const config of provider.configs) {
+      const relative = path.relative(path.join(cwd, config.output), dir);
+      if (
+        relative === '..' ||
+        relative.startsWith(`..${path.sep}`) ||
+        path.isAbsolute(relative)
+      )
+        continue;
+      const source = path.resolve(cwd, config.input, relative, 'package.json');
+      if (
+        isFile(source) &&
+        provider.getConfigForFile(winPath(path.relative(cwd, source))) ===
+          config
+      ) {
+        return JSON.parse(fs.readFileSync(source, 'utf-8')).type;
+      }
+    }
+    const packageFile = path.join(dir, 'package.json');
+    if (isFile(packageFile))
+      return JSON.parse(fs.readFileSync(packageFile, 'utf-8')).type;
+    dir = path.dirname(dir);
+  }
+  return provider.pkg.type;
+}
+
+export function getOutputFile(
+  sourceFile: string,
+  cwd: string,
+  provider: BundlessConfigProvider,
+) {
+  const config = provider.getConfigForFile(
+    winPath(path.relative(cwd, sourceFile)),
+  )!;
+  const file = path.join(
+    cwd,
+    config.output,
+    path.relative(config.input, path.relative(cwd, sourceFile)),
+  );
+  if (!config.autoExtension) return file;
+  const modulePackage = getPackageType(file, cwd, provider) === 'module';
+  const extension =
+    config.format === IFatherBundlessTypes.ESM
+      ? modulePackage
+        ? '.js'
+        : '.mjs'
+      : modulePackage
+      ? '.cjs'
+      : '.js';
+  // Explicit .mjs/.cjs and .d.mts/.d.cts assets retain their module identity.
+  return file
+    .replace(
+      /\.d\.ts(?=\.map$|$)/,
+      `.d.${extension.slice(1).replace('js', 'ts')}`,
+    )
+    .replace(/(?<!\.d)\.(tsx?|jsx?)(?=\.map$|$)/, extension);
+}
+
+export function getDeclarationFile(file: string, runtimeFile: string) {
+  const extension = path.extname(runtimeFile).slice(1).replace('js', 'ts');
+  return file.replace(/\.d\.ts(?=\.map$|$)/, `.d.${extension}`);
+}
+
+function redirects(config: IBundlessConfig, declaration: boolean) {
+  return (
+    config.redirect?.[declaration ? 'dts' : 'js']?.extension ??
+    config.autoExtension ??
+    false
+  );
 }
 
 const runtimeExtensions = ['.js', '.mjs', '.cjs'];
@@ -89,8 +169,11 @@ function resolveRelativeSpecifier(
   ];
   const source =
     findFile(sourceRequest, sourceExtensions) ||
-    (/\.js$/.test(request)
-      ? findFile(sourceRequest.slice(0, -3), sourceExtensions)
+    (/\.[cm]?js$/.test(request)
+      ? findFile(
+          sourceRequest.slice(0, -path.extname(sourceRequest).length),
+          sourceExtensions,
+        )
       : undefined);
   let target: string | undefined;
   if (source) {
@@ -98,11 +181,7 @@ function resolveRelativeSpecifier(
       winPath(path.relative(cwd, source)),
     );
     if (config) {
-      const emitted = path.resolve(
-        cwd,
-        config.output,
-        path.relative(config.input, path.relative(cwd, source)),
-      );
+      const emitted = getOutputFile(source, cwd, provider);
       const runtime = getRuntimePath(emitted);
       if (isFile(runtime) || (isDeclaration && isFile(emitted))) {
         target = runtime;
@@ -123,7 +202,7 @@ function resolveRelativeSpecifier(
   }
   if (path.extname(request)) return specifier;
   throw new Error(
-    `Cannot resolve fully specified ESM import ${JSON.stringify(
+    `Cannot resolve module reference ${JSON.stringify(
       specifier,
     )} from ${path.relative(cwd, output.file)}`,
   );
@@ -135,7 +214,7 @@ function rewriteOutput(
   provider: BundlessConfigProvider,
   config: IBundlessConfig,
 ) {
-  // Load the parser only when ESM import rewriting is enabled.
+  // Load the parser only when module reference rewriting is enabled.
   const ts: typeof import('typescript') = require('typescript');
   const content = fs.readFileSync(output.file, 'utf-8');
   const source = ts.createSourceFile(
@@ -151,7 +230,7 @@ function rewriteOutput(
     const specifier = node.text;
     const isRelative = /^(?:\.\.?\/|\.\.?$)/.test(specifier);
     const replacement = isRelative
-      ? config.fullySpecified
+      ? redirects(config, source.isDeclarationFile)
         ? resolveRelativeSpecifier(specifier, output, cwd, provider)
         : specifier
       : config.resolveDepSubpath
@@ -174,6 +253,19 @@ function rewriteOutput(
       node.expression.kind === ts.SyntaxKind.ImportKeyword
     ) {
       replace(node.arguments[0]);
+    } else if (
+      config.format === IFatherBundlessTypes.CJS &&
+      ts.isCallExpression(node) &&
+      ((ts.isIdentifier(node.expression) &&
+        node.expression.text === 'require') ||
+        (ts.isPropertyAccessExpression(node.expression) &&
+          ts.isIdentifier(node.expression.expression) &&
+          node.expression.expression.text === 'require' &&
+          node.expression.name.text === 'resolve'))
+    ) {
+      replace(node.arguments[0]);
+    } else if (ts.isExternalModuleReference(node) && source.isDeclarationFile) {
+      replace(node.expression);
     } else if (
       ts.isImportTypeNode(node) &&
       ts.isLiteralTypeNode(node.argument)
@@ -204,7 +296,7 @@ function rewriteOutput(
   fs.writeFileSync(output.file, result.toString());
 }
 
-export function finalizeEsm(
+export function finalizeOutputs(
   outputs: IOutputFile[],
   cwd: string,
   provider: BundlessConfigProvider,
@@ -212,9 +304,10 @@ export function finalizeEsm(
   if (
     !provider.configs.some(
       (config) =>
-        config.fullySpecified ||
-        config.resolveDepSubpath ||
-        config.outputPackageType,
+        config.autoExtension ||
+        redirects(config, false) ||
+        redirects(config, true) ||
+        config.resolveDepSubpath,
     )
   )
     return;
@@ -224,55 +317,60 @@ export function finalizeEsm(
       winPath(path.relative(cwd, output.sourceFile)),
     ),
   }));
-  // tsc emits maps relative to its declaration location; Father relocates
-  // declarations to the configured output (possibly an override directory).
+  // Generated declarations are relocated after tsc emits them. Copied maps
+  // already describe their own sources and must retain those mappings.
   for (const output of enabledOutputs) {
     if (
-      output.config?.fullySpecified &&
-      /\.d\.[cm]?ts\.map$/.test(output.file) &&
-      isFile(output.file)
-    ) {
-      const map = JSON.parse(fs.readFileSync(output.file, 'utf-8'));
-      if (!map.sourceRoot) {
-        map.sources = [
-          winPath(path.relative(path.dirname(output.file), output.sourceFile)),
-        ];
-        fs.writeFileSync(output.file, JSON.stringify(map));
-      }
+      !output.config ||
+      !isFile(output.file) ||
+      !/\.d\.[cm]?ts\.map$/.test(output.file)
+    )
+      continue;
+    if (
+      !redirects(output.config, true) &&
+      !output.config.autoExtension &&
+      !output.config.resolveDepSubpath
+    )
+      continue;
+    const map = JSON.parse(fs.readFileSync(output.file, 'utf-8'));
+    if (!/\.d\.[cm]?ts(?:\.map)?$/.test(output.sourceFile) && !map.sourceRoot) {
+      map.sources = [
+        winPath(path.relative(path.dirname(output.file), output.sourceFile)),
+      ];
     }
+    if (output.config.autoExtension)
+      map.file = path.basename(output.file.slice(0, -4));
+    fs.writeFileSync(output.file, JSON.stringify(map));
   }
   for (const output of enabledOutputs) {
     const config = output.config;
     if (
-      (config?.fullySpecified || config?.resolveDepSubpath) &&
-      /(?:\.m?js|\.d\.[cm]?ts)$/.test(output.file) &&
-      isFile(output.file)
+      !config ||
+      !/(?:\.[cm]?js|\.d\.[cm]?ts)$/.test(output.file) ||
+      !isFile(output.file)
+    )
+      continue;
+    if (config.autoExtension) {
+      const mapFile = `${output.file}.map`;
+      if (isFile(mapFile)) {
+        const map = JSON.parse(fs.readFileSync(mapFile, 'utf-8'));
+        map.file = path.basename(output.file);
+        fs.writeFileSync(mapFile, JSON.stringify(map));
+        const content = fs.readFileSync(output.file, 'utf-8');
+        fs.writeFileSync(
+          output.file,
+          content.replace(
+            /^([ \t]*\/\/[#@] sourceMappingURL=)[^\r\n]+$/gm,
+            `$1${path.basename(mapFile)}`,
+          ),
+        );
+      }
+    }
+    if (
+      redirects(config, /\.d\.[cm]?ts$/.test(output.file)) ||
+      config.resolveDepSubpath
     ) {
       rewriteOutput(output, cwd, provider, config);
-    }
-  }
-  // A package marker is independent of import rewriting. Include relocated
-  // overrides and copied package scopes while preserving their other metadata.
-  const packageFiles = new Set(
-    provider.configs
-      .filter((config) => config.outputPackageType === 'module')
-      .map((config) => path.resolve(cwd, config.output, 'package.json')),
-  );
-  enabledOutputs
-    .filter(
-      (output) =>
-        output.config?.outputPackageType === 'module' &&
-        path.basename(output.file) === 'package.json',
-    )
-    .forEach((output) => packageFiles.add(output.file));
-  for (const file of packageFiles) {
-    const pkg = isFile(file) ? JSON.parse(fs.readFileSync(file, 'utf-8')) : {};
-    if (pkg.type !== 'module') {
-      fs.mkdirSync(path.dirname(file), { recursive: true });
-      fs.writeFileSync(
-        file,
-        `${JSON.stringify({ ...pkg, type: 'module' }, null, 2)}\n`,
-      );
     }
   }
 }

--- a/src/builder/config.ts
+++ b/src/builder/config.ts
@@ -43,6 +43,9 @@ export interface IBundlessConfig
   format: IFatherBundlessTypes;
   input: string;
   parallel: boolean;
+  fullySpecified?: boolean;
+  resolveDepSubpath?: boolean;
+  outputPackageType?: 'module';
   output: NonNullable<IFatherBundlessConfig['output']>;
 }
 
@@ -407,6 +410,34 @@ export function createConfigProviders(
     bundle?: BundleConfigProvider;
   } = { bundless: {} };
   const configs = normalizeUserConfig(userConfig, pkg);
+
+  // A package marker would also change how Node interprets a CJS output
+  // sharing that directory. Reject this before the builder cleans outputs.
+  const modulePackageConfigs = configs.filter(
+    (config): config is IBundlessConfig =>
+      config.type === IFatherBuildTypes.BUNDLESS &&
+      config.outputPackageType === 'module',
+  );
+  const cjsConfigs = configs.filter(
+    (config): config is IBundlessConfig =>
+      config.type === IFatherBuildTypes.BUNDLESS &&
+      config.format === IFatherBundlessTypes.CJS,
+  );
+  for (const esmConfig of modulePackageConfigs) {
+    const esmOutput = path.resolve(cwd, esmConfig.output);
+    for (const cjsConfig of cjsConfigs) {
+      const cjsOutput = path.resolve(cwd, cjsConfig.output);
+      if (
+        esmOutput === cjsOutput ||
+        cjsOutput.startsWith(`${esmOutput}${path.sep}`) ||
+        esmOutput.startsWith(`${cjsOutput}${path.sep}`)
+      ) {
+        throw new Error(
+          'ESM outputPackageType and CJS outputs must use separate directories.',
+        );
+      }
+    }
+  }
 
   // convert alias from tsconfig paths
   const aliasFromPaths = convertAliasByTsconfigPaths(cwd);

--- a/src/builder/config.ts
+++ b/src/builder/config.ts
@@ -43,9 +43,7 @@ export interface IBundlessConfig
   format: IFatherBundlessTypes;
   input: string;
   parallel: boolean;
-  fullySpecified?: boolean;
   resolveDepSubpath?: boolean;
-  outputPackageType?: 'module';
   output: NonNullable<IFatherBundlessConfig['output']>;
 }
 
@@ -410,34 +408,6 @@ export function createConfigProviders(
     bundle?: BundleConfigProvider;
   } = { bundless: {} };
   const configs = normalizeUserConfig(userConfig, pkg);
-
-  // A package marker would also change how Node interprets a CJS output
-  // sharing that directory. Reject this before the builder cleans outputs.
-  const modulePackageConfigs = configs.filter(
-    (config): config is IBundlessConfig =>
-      config.type === IFatherBuildTypes.BUNDLESS &&
-      config.outputPackageType === 'module',
-  );
-  const cjsConfigs = configs.filter(
-    (config): config is IBundlessConfig =>
-      config.type === IFatherBuildTypes.BUNDLESS &&
-      config.format === IFatherBundlessTypes.CJS,
-  );
-  for (const esmConfig of modulePackageConfigs) {
-    const esmOutput = path.resolve(cwd, esmConfig.output);
-    for (const cjsConfig of cjsConfigs) {
-      const cjsOutput = path.resolve(cwd, cjsConfig.output);
-      if (
-        esmOutput === cjsOutput ||
-        cjsOutput.startsWith(`${esmOutput}${path.sep}`) ||
-        esmOutput.startsWith(`${cjsOutput}${path.sep}`)
-      ) {
-        throw new Error(
-          'ESM outputPackageType and CJS outputs must use separate directories.',
-        );
-      }
-    }
-  }
 
   // convert alias from tsconfig paths
   const aliasFromPaths = convertAliasByTsconfigPaths(cwd);

--- a/src/features/configPlugins/schema.ts
+++ b/src/features/configPlugins/schema.ts
@@ -61,7 +61,12 @@ export function getSchemas(): Record<string, (Joi: Root) => any> {
   return {
     ...getCommonSchemas(),
     extends: (Joi) => Joi.string(),
-    esm: (Joi) => getBundlessSchemas(Joi),
+    esm: (Joi) =>
+      getBundlessSchemas(Joi).keys({
+        fullySpecified: Joi.boolean(),
+        resolveDepSubpath: Joi.boolean(),
+        outputPackageType: Joi.equal('module'),
+      }),
     cjs: (Joi) => getBundlessSchemas(Joi),
     umd: (Joi) =>
       Joi.object({

--- a/src/features/configPlugins/schema.ts
+++ b/src/features/configPlugins/schema.ts
@@ -44,6 +44,11 @@ function getCommonSchemasJoi(Joi: Root) {
 function getBundlessSchemas(Joi: Root) {
   return Joi.object({
     ...getCommonSchemasJoi(Joi),
+    autoExtension: Joi.boolean(),
+    redirect: Joi.object({
+      js: Joi.object({ extension: Joi.boolean() }),
+      dts: Joi.object({ extension: Joi.boolean() }),
+    }),
     input: Joi.string(),
     output: Joi.string(),
     transformer: Joi.equal(
@@ -63,9 +68,7 @@ export function getSchemas(): Record<string, (Joi: Root) => any> {
     extends: (Joi) => Joi.string(),
     esm: (Joi) =>
       getBundlessSchemas(Joi).keys({
-        fullySpecified: Joi.boolean(),
         resolveDepSubpath: Joi.boolean(),
-        outputPackageType: Joi.equal('module'),
       }),
     cjs: (Joi) => getBundlessSchemas(Joi),
     umd: (Joi) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -187,6 +187,21 @@ export interface IFatherBaseConfig {
 
 export interface IFatherBundlessConfig extends IFatherBaseConfig {
   /**
+   * choose .js/.mjs/.cjs by package type and match declaration extensions
+   * @default false
+   */
+  autoExtension?: boolean;
+
+  /**
+   * complete module references in JavaScript and declarations independently
+   * @default each extension option follows autoExtension (false by default)
+   */
+  redirect?: {
+    js?: { extension?: boolean };
+    dts?: { extension?: boolean };
+  };
+
+  /**
    * source code directory
    * @default src
    */
@@ -337,22 +352,10 @@ export interface IFatherConfig extends IFatherBaseConfig {
    */
   esm?: IFatherBundlessConfig & {
     /**
-     * complete relative module specifiers in JavaScript and declarations
-     * @default false
-     */
-    fullySpecified?: boolean;
-
-    /**
-     * resolve external dependency subpaths for packages without exports
+     * resolve dependency subpaths for packages without exports
      * @default false
      */
     resolveDepSubpath?: boolean;
-
-    /**
-     * write a package.json type marker in ESM output directories
-     * @default undefined (do not generate or modify package metadata)
-     */
-    outputPackageType?: 'module';
 
     /**
      * output directory

--- a/src/types.ts
+++ b/src/types.ts
@@ -337,6 +337,24 @@ export interface IFatherConfig extends IFatherBaseConfig {
    */
   esm?: IFatherBundlessConfig & {
     /**
+     * complete relative module specifiers in JavaScript and declarations
+     * @default false
+     */
+    fullySpecified?: boolean;
+
+    /**
+     * resolve external dependency subpaths for packages without exports
+     * @default false
+     */
+    resolveDepSubpath?: boolean;
+
+    /**
+     * write a package.json type marker in ESM output directories
+     * @default undefined (do not generate or modify package metadata)
+     */
+    outputPackageType?: 'module';
+
+    /**
      * output directory
      * @default dist/esm
      */

--- a/tests/dev.test.ts
+++ b/tests/dev.test.ts
@@ -138,37 +138,20 @@ test('dev: file change', async () => {
     'utf-8',
   );
 
-  await Promise.all([
-    // wait for watch debounce and compile
-    wait(WATCH_DEBOUNCE_STEP + 500),
-    // wait for webpack compilation done
-    new Promise<void>((resolve) => {
-      const logSpy = jest.spyOn(console, 'log');
-      const handler = () => {
-        try {
-          expect(console.log).toHaveBeenCalledWith(
-            // badge
-            expect.stringContaining('-'),
-            // time
-            expect.stringContaining('['),
-            // content
-            expect.stringContaining('Bundle '),
-          );
-          logSpy.mockRestore();
-          resolve();
-        } catch {
-          setTimeout(handler, 500);
-        }
-      };
-
-      handler();
-    }),
-  ]);
-
-  const fileMap = distToMap(CASE_DIST);
-
-  expect(fileMap['esm/index.js']).toContain(content);
-  expect(fileMap['umd/index.min.js']).toContain(content);
+  // Webpack and bundless transforms finish independently. Wait for both
+  // outputs instead of treating a webpack log and a fixed delay as completion.
+  const deadline = Date.now() + 15000;
+  while (true) {
+    try {
+      const fileMap = distToMap(CASE_DIST);
+      expect(fileMap['esm/index.js']).toContain(content);
+      expect(fileMap['umd/index.min.js']).toContain(content);
+      break;
+    } catch (error) {
+      if (Date.now() >= deadline) throw error;
+      await wait(100);
+    }
+  }
 });
 
 test('dev: file add', async () => {

--- a/tests/esm-output.test.ts
+++ b/tests/esm-output.test.ts
@@ -1,0 +1,574 @@
+import { MagicString, remapping } from '@umijs/utils';
+import Joi from '@umijs/utils/compiled/@hapi/joi';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import builder from '../src/builder';
+import { addLoader, addTransformer } from '../src/builder/bundless';
+import { finalizeEsm } from '../src/builder/bundless/esm';
+import { createConfigProviders } from '../src/builder/config';
+import { getSchemas } from '../src/features/configPlugins/schema';
+import type { IFatherConfig } from '../src/types';
+import { distToMap } from './utils';
+
+const fixtures: string[] = [];
+const compiled = path.resolve(__dirname, '../dist/builder/bundless/loaders');
+
+beforeAll(() => {
+  process.env.FATHER_CACHE = 'none';
+  addLoader({
+    id: 'js',
+    test: /((?<!\.d)\.ts|\.(jsx?|tsx))$/,
+    loader: path.join(compiled, 'javascript/index.js'),
+  });
+  for (const transformer of ['babel', 'esbuild', 'swc']) {
+    addTransformer({
+      id: transformer,
+      transformer: path.join(compiled, `javascript/${transformer}.js`),
+    });
+  }
+});
+
+afterAll(() => {
+  delete process.env.FATHER_CACHE;
+  fixtures.forEach((cwd) => fs.rmSync(cwd, { recursive: true, force: true }));
+});
+
+function write(cwd: string, file: string, content: string | object) {
+  const target = path.join(cwd, file);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(
+    target,
+    typeof content === 'string' ? content : JSON.stringify(content),
+  );
+}
+
+function fixture(files: Record<string, string | object>) {
+  const cwd = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'father-native-esm-')),
+  );
+  fixtures.push(cwd);
+  Object.entries(files).forEach(([file, content]) => write(cwd, file, content));
+  return cwd;
+}
+
+function read(cwd: string, file: string) {
+  return fs.readFileSync(path.join(cwd, file), 'utf-8');
+}
+
+const pkg = {
+  name: 'native-esm-fixture',
+  exports: {
+    '.': { import: './dist/esm/index.js', require: './dist/cjs/index.js' },
+  },
+};
+
+const tsconfig = {
+  compilerOptions: {
+    target: 'es2020',
+    module: 'esnext',
+    moduleResolution: 'node',
+    declaration: true,
+    declarationMap: true,
+    esModuleInterop: true,
+    strict: true,
+    baseUrl: '.',
+    paths: { '@/*': ['./src/*'] },
+    types: [],
+  },
+  include: ['src'],
+};
+
+const esmOptions = {
+  fullySpecified: true,
+  resolveDepSubpath: true,
+  outputPackageType: 'module',
+} as const;
+
+test.each([
+  {},
+  { main: './dist/cjs/index.js', module: './dist/esm/index.js' },
+  { type: 'module' },
+  { exports: { import: './dist/esm/index.js' } },
+  { exports: pkg.exports },
+  {
+    exports: {
+      './*': {
+        node: {
+          import: { types: './dist/esm/*.d.ts', default: './dist/esm/*.js' },
+        },
+      },
+    },
+  },
+  { exports: { import: [null, './dist/esm/index.js'] } },
+])(
+  'package metadata does not enable ESM processing: %j',
+  async (packageJson) => {
+    const cwd = fixture({
+      'package.json': packageJson,
+      'src/index.js': "export * from './nested';",
+      'src/index.d.ts': "export * from './nested';",
+      'src/nested/index.js': 'export const value = 1;',
+      'src/nested/index.d.ts': 'export declare const value: 1;',
+      'src/nested/package.json':
+        '{ "sideEffects": false, "type": "commonjs" }\n',
+    });
+    const userConfig: IFatherConfig = {
+      esm: { transformer: 'esbuild' },
+      cjs: {},
+    };
+    const config = createConfigProviders(userConfig, packageJson, cwd).bundless
+      .esm!.configs[0];
+    expect(config.fullySpecified).toBeUndefined();
+    expect(config.resolveDepSubpath).toBeUndefined();
+    expect(config.outputPackageType).toBeUndefined();
+    await builder({ cwd, pkg: packageJson, userConfig });
+    const original = distToMap(path.join(cwd, 'dist'));
+    expect(original['esm/package.json']).toBeUndefined();
+    for (const file of ['index.js', 'index.d.ts']) {
+      expect(read(cwd, `dist/esm/${file}`)).toContain('./nested');
+      expect(read(cwd, `dist/esm/${file}`)).not.toContain('./nested/index.js');
+    }
+    expect(read(cwd, 'dist/esm/nested/package.json')).toBe(
+      read(cwd, 'src/nested/package.json'),
+    );
+    await builder({
+      cwd,
+      pkg: packageJson,
+      userConfig: {
+        ...userConfig,
+        esm: {
+          ...userConfig.esm,
+          fullySpecified: false,
+          resolveDepSubpath: false,
+        },
+      },
+    });
+    expect(distToMap(path.join(cwd, 'dist'))).toEqual(original);
+  },
+);
+
+test('output options are ESM-only and validate independently', () => {
+  expect(getSchemas().esm(Joi).validate(esmOptions).error).toBeUndefined();
+  for (const options of [
+    { fullySpecified: 'invalid' },
+    { resolveDepSubpath: 'invalid' },
+    { outputPackageType: 'commonjs' },
+  ])
+    expect(getSchemas().esm(Joi).validate(options).error).toBeDefined();
+  for (const options of [
+    { fullySpecified: true },
+    { resolveDepSubpath: true },
+    { outputPackageType: 'module' },
+  ])
+    expect(getSchemas().cjs(Joi).validate(options).error).toBeDefined();
+});
+
+test.each(['dist/cjs', 'dist', 'dist/cjs/nested'])(
+  'rejects package markers overlapping CJS output %s before cleaning',
+  async (output) => {
+    const cwd = fixture({ 'dist/cjs/existing.js': 'keep me' });
+    expect(() =>
+      createConfigProviders(
+        { esm: { fullySpecified: true, output }, cjs: {} },
+        pkg,
+        cwd,
+      ),
+    ).not.toThrow();
+    await expect(
+      builder({
+        cwd,
+        pkg,
+        userConfig: { esm: { outputPackageType: 'module', output }, cjs: {} },
+      }),
+    ).rejects.toThrow('separate directories');
+    expect(read(cwd, 'dist/cjs/existing.js')).toBe('keep me');
+  },
+);
+
+test.each([
+  [false, false, false],
+  [true, false, false],
+  [false, true, false],
+  [false, false, true],
+  [true, true, false],
+  [true, false, true],
+  [false, true, true],
+  [true, true, true],
+])(
+  'options act independently: relative=%s dependencies=%s package=%s',
+  async (fullySpecified, resolveDepSubpath, marker) => {
+    const cwd = fixture({
+      'package.json': pkg,
+      'src/index.js':
+        "export * from './nested'; export { default as plugin } from 'legacy/plugin';",
+      'src/index.d.ts':
+        "export * from './nested'; export { default as plugin } from 'legacy/plugin';",
+      'src/nested/index.js': 'export const value = 1;',
+      'src/nested/index.d.ts': 'export declare const value: 1;',
+      'src/nested/package.json':
+        '{ "sideEffects": false, "type": "commonjs" }\n',
+      'node_modules/legacy/package.json': { name: 'legacy' },
+      'node_modules/legacy/plugin.js': 'module.exports = 7;',
+    });
+    await builder({
+      cwd,
+      pkg,
+      userConfig: {
+        esm: {
+          transformer: 'esbuild',
+          fullySpecified,
+          resolveDepSubpath,
+          ...(marker ? { outputPackageType: 'module' } : {}),
+        },
+      },
+    });
+    for (const file of ['index.js', 'index.d.ts']) {
+      const content = read(cwd, `dist/esm/${file}`);
+      expect(content.includes('./nested/index.js')).toBe(fullySpecified);
+      expect(content.includes('legacy/plugin.js')).toBe(resolveDepSubpath);
+    }
+    if (marker) {
+      expect(JSON.parse(read(cwd, 'dist/esm/package.json'))).toEqual({
+        type: 'module',
+      });
+      expect(JSON.parse(read(cwd, 'dist/esm/nested/package.json'))).toEqual({
+        sideEffects: false,
+        type: 'module',
+      });
+    } else {
+      expect(fs.existsSync(path.join(cwd, 'dist/esm/package.json'))).toBe(
+        false,
+      );
+      expect(read(cwd, 'dist/esm/nested/package.json')).toBe(
+        read(cwd, 'src/nested/package.json'),
+      );
+    }
+  },
+);
+
+test.each(['babel', 'esbuild', 'swc'] as const)(
+  '%s emits native ESM and NodeNext declarations while preserving CJS',
+  async (transformer) => {
+    const cwd = fixture({
+      'package.json': pkg,
+      'tsconfig.json': tsconfig,
+      'src/index.ts': `
+      export { value } from '@/value';
+      export * from './nested';
+      export { default as legacy } from 'legacy/plugin';
+      export { default as modern } from 'modern/feature';
+      export const load = () => import('./nested');
+      export type Value = import('./value').Value;
+    `,
+      'src/value.ts':
+        'export const value = 42; export interface Value { value: number }',
+      'src/nested/index.ts': "export { value as nested } from '../value';",
+      'node_modules/legacy/package.json': { name: 'legacy' },
+      'node_modules/legacy/plugin.js': 'module.exports = 7;',
+      'node_modules/legacy/plugin.d.ts':
+        'declare const plugin: 7; export = plugin;',
+      'node_modules/modern/package.json': {
+        name: 'modern',
+        type: 'module',
+        exports: {
+          './feature': {
+            types: './feature.d.ts',
+            import: './feature.js',
+            require: './feature.cjs',
+          },
+        },
+      },
+      'node_modules/modern/feature.js': 'export default 8;',
+      'node_modules/modern/feature.cjs': 'module.exports = 8;',
+      'node_modules/modern/feature.d.ts':
+        'declare const feature: 8; export default feature;',
+    });
+    const userConfig: IFatherConfig = {
+      esm: { transformer, ...esmOptions },
+      cjs: {},
+      sourcemap: true,
+      targets: { node: '18' },
+    };
+    await builder({ cwd, pkg, userConfig });
+    const firstCjs = distToMap(path.join(cwd, 'dist/cjs'));
+    const esm = read(cwd, 'dist/esm/index.js');
+    const dts = read(cwd, 'dist/esm/index.d.ts');
+    expect(esm).toContain('./value.js');
+    expect(esm).toContain('./nested/index.js');
+    expect(esm).toContain('legacy/plugin.js');
+    expect(esm).toContain('modern/feature');
+    expect(esm).not.toContain('modern/feature.js');
+    expect(dts).toContain('./value.js');
+    expect(dts).toContain('./nested/index.js');
+    expect(dts).toContain('legacy/plugin.js');
+    expect(JSON.parse(read(cwd, 'dist/esm/package.json'))).toEqual({
+      type: 'module',
+    });
+    for (const file of ['index.js.map', 'index.d.ts.map']) {
+      const map = JSON.parse(read(cwd, `dist/esm/${file}`));
+      expect(map.sources).toEqual(['../../src/index.ts']);
+      expect(map.mappings).not.toBe('');
+    }
+    const result = execFileSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '-e',
+        `
+    import { createRequire } from 'node:module';
+    const esm = await import('native-esm-fixture');
+    const cjs = createRequire(import.meta.url)('native-esm-fixture');
+    console.log(JSON.stringify([esm.value, esm.nested, (await esm.load()).nested, esm.legacy, esm.modern, cjs.value, cjs.legacy, cjs.modern]));
+  `,
+      ],
+      { cwd, encoding: 'utf-8' },
+    );
+    expect(JSON.parse(result)).toEqual([42, 42, 42, 7, 8, 42, 7, 8]);
+    write(
+      cwd,
+      'consumer.mts',
+      `import { value, nested, legacy, modern, load, type Value } from 'native-esm-fixture';
+    const n: number = value + nested + legacy + modern;
+    const v: Value = { value: n };
+    load().then(m => { const x: number = m.nested; });`,
+    );
+    try {
+      execFileSync(
+        process.execPath,
+        [
+          require.resolve('typescript/bin/tsc'),
+          '--noEmit',
+          '--strict',
+          '--module',
+          'NodeNext',
+          '--moduleResolution',
+          'NodeNext',
+          '--target',
+          'es2020',
+          'consumer.mts',
+        ],
+        { cwd, stdio: 'pipe' },
+      );
+    } catch (error: any) {
+      throw new Error(error.stdout?.toString() || error.message);
+    }
+    await builder({
+      cwd,
+      pkg,
+      userConfig: { ...userConfig, esm: { transformer } },
+    });
+    expect(distToMap(path.join(cwd, 'dist/cjs'))).toEqual(firstCjs);
+    expect(fs.existsSync(path.join(cwd, 'dist/esm/package.json'))).toBe(false);
+    expect(read(cwd, 'dist/esm/index.js')).not.toContain('./value.js');
+  },
+);
+
+test('rewrites only module specifiers, preserves suffixes, and composes source maps', () => {
+  const code = `import './value'; export const after = 1;
+// import './missing';
+const text = "import './missing'";
+const untouched = require('./value');
+import('./nested?raw=1#hash');
+import(name);
+export * from './dotted.name';
+export * from './module.mjs';
+import './style.css';
+import '#internal';
+import 'node:fs/promises';
+import 'optional/missing';
+import 'https://example.com/module';
+import '@scope/legacy/nested';
+export { explicit } from './explicit.ts';
+`;
+  const cwd = fixture({
+    'dist/esm/index.js': code,
+    'dist/esm/value.js': 'export const value = 1;',
+    'dist/esm/nested/index.js': 'export {};',
+    'dist/esm/dotted.name.js': 'export {};',
+    'dist/esm/module.mjs': 'export {};',
+    'dist/esm/style.css': '',
+    'src/explicit.ts': 'export const explicit = 1;',
+    'dist/esm/explicit.js': 'export const explicit = 1;',
+    'node_modules/@scope/legacy/package.json': { name: '@scope/legacy' },
+    'node_modules/@scope/legacy/nested/index.js': 'module.exports = 1;',
+    'dist/esm/index.d.ts': `export type T = import('./types').T;
+declare module './value' { export const added: number; }
+declare const untouched: "from './missing'";
+// export * from './missing';
+`,
+    'dist/esm/types.d.ts': 'export interface T {}',
+    'dist/esm/package.json': { sideEffects: false, type: 'commonjs' },
+  });
+  const map = new MagicString(code).generateMap({
+    hires: true,
+    source: '../../src/index.ts',
+    includeContent: true,
+  });
+  write(cwd, 'dist/esm/index.js.map', map);
+  const provider = createConfigProviders({ esm: { ...esmOptions } }, {}, cwd)
+    .bundless.esm!;
+  const outputs = ['index.js', 'index.d.ts'].map((file) => ({
+    file: path.join(cwd, 'dist/esm', file),
+    sourceFile: path.join(cwd, 'src/index.ts'),
+  }));
+  finalizeEsm(outputs, cwd, provider);
+  const result = read(cwd, 'dist/esm/index.js');
+  expect(result).toContain('./nested/index.js?raw=1#hash');
+  expect(result).toContain('./dotted.name.js');
+  expect(result).toContain('./explicit.js');
+  expect(result).toContain('@scope/legacy/nested/index.js');
+  for (const unchanged of [
+    "// import './missing';",
+    '"import \'./missing\'"',
+    "require('./value')",
+    'import(name)',
+    "'./module.mjs'",
+    "'./style.css'",
+    "'#internal'",
+    "'node:fs/promises'",
+    "'optional/missing'",
+    "'https://example.com/module'",
+  ])
+    expect(result).toContain(unchanged);
+  expect(read(cwd, 'dist/esm/index.d.ts')).toContain('import("./types.js")');
+  expect(read(cwd, 'dist/esm/index.d.ts')).toContain('module "./value.js"');
+  expect(read(cwd, 'dist/esm/index.d.ts')).toContain('"from \'./missing\'"');
+  expect(JSON.parse(read(cwd, 'dist/esm/package.json'))).toEqual({
+    sideEffects: false,
+    type: 'module',
+  });
+  // Inspect the decoded mapping after the longer import on the same line.
+  const composed = remapping(
+    JSON.parse(read(cwd, 'dist/esm/index.js.map')),
+    () => null,
+    { decodedMappings: true },
+  );
+  expect(composed.mappings[0]).toContainEqual([
+    result.indexOf('after'),
+    0,
+    0,
+    code.indexOf('after'),
+  ]);
+  const files = distToMap(path.join(cwd, 'dist'));
+  finalizeEsm(outputs, cwd, provider);
+  expect(distToMap(path.join(cwd, 'dist'))).toEqual(files);
+});
+
+test('reports unresolved relative modules with the importing file', async () => {
+  const cwd = fixture({ 'src/index.js': "export * from './missing';" });
+  await expect(
+    builder({ cwd, pkg: {}, userConfig: { esm: { fullySpecified: true } } }),
+  ).rejects.toThrow(
+    'Cannot resolve fully specified ESM import "./missing" from dist',
+  );
+});
+
+test('relocates overrides, marks copied package scopes, and handles cache hits', async () => {
+  const cwd = fixture({
+    'package.json': pkg,
+    'tsconfig.json': tsconfig,
+    'src/index.ts': "export { value } from './nested';",
+    'src/nested/index.ts': 'export const value = 12;',
+    'src/nested/package.json': { sideEffects: false, type: 'commonjs' },
+  });
+  const userConfig: IFatherConfig = {
+    esm: {
+      fullySpecified: true,
+      outputPackageType: 'module',
+      overrides: { 'src/nested': { output: 'custom/nested' } },
+    },
+  };
+  delete process.env.FATHER_CACHE;
+  try {
+    await builder({ cwd, pkg, userConfig });
+    expect(read(cwd, 'dist/esm/index.js')).toContain(
+      '../../custom/nested/index.js',
+    );
+    expect(read(cwd, 'dist/esm/index.d.ts')).toContain(
+      '../../custom/nested/index.js',
+    );
+    expect(JSON.parse(read(cwd, 'custom/nested/package.json'))).toEqual({
+      sideEffects: false,
+      type: 'module',
+    });
+    const first = distToMap(path.join(cwd, 'dist'));
+    await builder({ cwd, pkg, userConfig });
+    expect(distToMap(path.join(cwd, 'dist'))).toEqual(first);
+    expect(
+      execFileSync(
+        process.execPath,
+        [
+          '--input-type=module',
+          '-e',
+          `console.log((await import(${JSON.stringify(
+            pathToFileURL(path.join(cwd, 'dist/esm/index.js')).href,
+          )})).value)`,
+        ],
+        { encoding: 'utf-8' },
+      ).trim(),
+    ).toBe('12');
+  } finally {
+    process.env.FATHER_CACHE = 'none';
+  }
+});
+
+test('watch rewrites changed JS, copied declarations and newly added modules', async () => {
+  const cwd = fixture({ 'src/index.js': 'export const initial = 1;' });
+  const watcher = await builder({
+    cwd,
+    pkg: {},
+    userConfig: {
+      esm: {
+        fullySpecified: true,
+        outputPackageType: 'module',
+        transformer: 'esbuild',
+      },
+    },
+    watch: true,
+  });
+  try {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    write(cwd, 'src/new/index.js', 'export const value = 2;');
+    write(cwd, 'src/new/index.d.ts', 'export declare const value: 2;');
+    write(cwd, 'src/index.js', "export { value } from './new';");
+    write(cwd, 'src/index.d.ts', "export { value } from './new';");
+    const deadline = Date.now() + 15000;
+    while (true) {
+      if (
+        fs.existsSync(path.join(cwd, 'dist/esm/index.d.ts')) &&
+        read(cwd, 'dist/esm/index.js').includes('./new/index.js') &&
+        read(cwd, 'dist/esm/index.d.ts').includes('./new/index.js')
+      )
+        break;
+      if (Date.now() > deadline)
+        throw new Error('Timed out waiting for native ESM watch output');
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    expect(JSON.parse(read(cwd, 'dist/esm/package.json'))).toEqual({
+      type: 'module',
+    });
+  } finally {
+    await watcher.close();
+  }
+});
+
+test('parallel build finalizes native ESM after workers finish', () => {
+  const cwd = fixture({
+    'package.json': pkg,
+    'src/index.js': "export { value } from './nested';",
+    'src/nested/index.js': 'export const value = 5;',
+    '.fatherrc.js': `export default { esm: { parallel: true, fullySpecified: true, outputPackageType: 'module' } };`,
+  });
+  execFileSync(
+    process.execPath,
+    [path.resolve(__dirname, '../bin/father.js'), 'build'],
+    { cwd, env: { ...process.env, APP_ROOT: cwd }, stdio: 'pipe' },
+  );
+  expect(read(cwd, 'dist/esm/index.js')).toContain('./nested/index.js');
+  expect(JSON.parse(read(cwd, 'dist/esm/package.json'))).toEqual({
+    type: 'module',
+  });
+});

--- a/tests/esm-output.test.ts
+++ b/tests/esm-output.test.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import { pathToFileURL } from 'url';
 import builder from '../src/builder';
 import { addLoader, addTransformer } from '../src/builder/bundless';
-import { finalizeEsm } from '../src/builder/bundless/esm';
+import { finalizeOutputs } from '../src/builder/bundless/output';
 import { createConfigProviders } from '../src/builder/config';
 import { getSchemas } from '../src/features/configPlugins/schema';
 import type { IFatherConfig } from '../src/types';
@@ -81,11 +81,7 @@ const tsconfig = {
   include: ['src'],
 };
 
-const esmOptions = {
-  fullySpecified: true,
-  resolveDepSubpath: true,
-  outputPackageType: 'module',
-} as const;
+const redirect = { js: { extension: true }, dts: { extension: true } };
 
 test.each([
   {},
@@ -102,9 +98,8 @@ test.each([
       },
     },
   },
-  { exports: { import: [null, './dist/esm/index.js'] } },
 ])(
-  'package metadata does not enable ESM processing: %j',
+  'package metadata does not enable output processing: %j',
   async (packageJson) => {
     const cwd = fixture({
       'package.json': packageJson,
@@ -121,9 +116,9 @@ test.each([
     };
     const config = createConfigProviders(userConfig, packageJson, cwd).bundless
       .esm!.configs[0];
-    expect(config.fullySpecified).toBeUndefined();
+    expect(config.autoExtension).toBeUndefined();
+    expect(config.redirect).toBeUndefined();
     expect(config.resolveDepSubpath).toBeUndefined();
-    expect(config.outputPackageType).toBeUndefined();
     await builder({ cwd, pkg: packageJson, userConfig });
     const original = distToMap(path.join(cwd, 'dist'));
     expect(original['esm/package.json']).toBeUndefined();
@@ -134,59 +129,44 @@ test.each([
     expect(read(cwd, 'dist/esm/nested/package.json')).toBe(
       read(cwd, 'src/nested/package.json'),
     );
+    const disabled = {
+      autoExtension: false,
+      redirect: { js: { extension: false }, dts: { extension: false } },
+    };
     await builder({
       cwd,
       pkg: packageJson,
       userConfig: {
-        ...userConfig,
-        esm: {
-          ...userConfig.esm,
-          fullySpecified: false,
-          resolveDepSubpath: false,
-        },
+        esm: { ...userConfig.esm, ...disabled, resolveDepSubpath: false },
+        cjs: disabled,
       },
     });
     expect(distToMap(path.join(cwd, 'dist'))).toEqual(original);
   },
 );
 
-test('output options are ESM-only and validate independently', () => {
-  expect(getSchemas().esm(Joi).validate(esmOptions).error).toBeUndefined();
-  for (const options of [
-    { fullySpecified: 'invalid' },
-    { resolveDepSubpath: 'invalid' },
-    { outputPackageType: 'commonjs' },
-  ])
-    expect(getSchemas().esm(Joi).validate(options).error).toBeDefined();
-  for (const options of [
-    { fullySpecified: true },
-    { resolveDepSubpath: true },
-    { outputPackageType: 'module' },
-  ])
-    expect(getSchemas().cjs(Joi).validate(options).error).toBeDefined();
+test('validates shared output options and ESM-only dependency resolution', () => {
+  for (const format of ['esm', 'cjs']) {
+    const schema = getSchemas()[format](Joi);
+    expect(
+      schema.validate({ autoExtension: true, redirect }).error,
+    ).toBeUndefined();
+    for (const invalid of [
+      { autoExtension: 'invalid' },
+      { redirect: { js: { extension: 'invalid' } } },
+      { redirect: { dts: { extension: 'invalid' } } },
+      { fullySpecified: true },
+      { outputPackageType: 'module' },
+    ])
+      expect(schema.validate(invalid).error).toBeDefined();
+  }
+  expect(
+    getSchemas().esm(Joi).validate({ resolveDepSubpath: true }).error,
+  ).toBeUndefined();
+  expect(
+    getSchemas().cjs(Joi).validate({ resolveDepSubpath: true }).error,
+  ).toBeDefined();
 });
-
-test.each(['dist/cjs', 'dist', 'dist/cjs/nested'])(
-  'rejects package markers overlapping CJS output %s before cleaning',
-  async (output) => {
-    const cwd = fixture({ 'dist/cjs/existing.js': 'keep me' });
-    expect(() =>
-      createConfigProviders(
-        { esm: { fullySpecified: true, output }, cjs: {} },
-        pkg,
-        cwd,
-      ),
-    ).not.toThrow();
-    await expect(
-      builder({
-        cwd,
-        pkg,
-        userConfig: { esm: { outputPackageType: 'module', output }, cjs: {} },
-      }),
-    ).rejects.toThrow('separate directories');
-    expect(read(cwd, 'dist/cjs/existing.js')).toBe('keep me');
-  },
-);
 
 test.each([
   [false, false, false],
@@ -198,18 +178,15 @@ test.each([
   [false, true, true],
   [true, true, true],
 ])(
-  'options act independently: relative=%s dependencies=%s package=%s',
-  async (fullySpecified, resolveDepSubpath, marker) => {
+  'redirect and dependencies are independent: js=%s dts=%s deps=%s',
+  async (js, dts, resolveDepSubpath) => {
     const cwd = fixture({
-      'package.json': pkg,
       'src/index.js':
         "export * from './nested'; export { default as plugin } from 'legacy/plugin';",
       'src/index.d.ts':
         "export * from './nested'; export { default as plugin } from 'legacy/plugin';",
       'src/nested/index.js': 'export const value = 1;',
       'src/nested/index.d.ts': 'export declare const value: 1;',
-      'src/nested/package.json':
-        '{ "sideEffects": false, "type": "commonjs" }\n',
       'node_modules/legacy/package.json': { name: 'legacy' },
       'node_modules/legacy/plugin.js': 'module.exports = 7;',
     });
@@ -219,53 +196,60 @@ test.each([
       userConfig: {
         esm: {
           transformer: 'esbuild',
-          fullySpecified,
           resolveDepSubpath,
-          ...(marker ? { outputPackageType: 'module' } : {}),
+          redirect: { js: { extension: js }, dts: { extension: dts } },
         },
       },
     });
-    for (const file of ['index.js', 'index.d.ts']) {
+    for (const [file, enabled] of [
+      ['index.js', js],
+      ['index.d.ts', dts],
+    ] as const) {
       const content = read(cwd, `dist/esm/${file}`);
-      expect(content.includes('./nested/index.js')).toBe(fullySpecified);
+      expect(content.includes('./nested/index.js')).toBe(enabled);
       expect(content.includes('legacy/plugin.js')).toBe(resolveDepSubpath);
     }
-    if (marker) {
-      expect(JSON.parse(read(cwd, 'dist/esm/package.json'))).toEqual({
-        type: 'module',
-      });
-      expect(JSON.parse(read(cwd, 'dist/esm/nested/package.json'))).toEqual({
-        sideEffects: false,
-        type: 'module',
-      });
-    } else {
-      expect(fs.existsSync(path.join(cwd, 'dist/esm/package.json'))).toBe(
-        false,
-      );
-      expect(read(cwd, 'dist/esm/nested/package.json')).toBe(
-        read(cwd, 'src/nested/package.json'),
-      );
-    }
+    expect(fs.existsSync(path.join(cwd, 'dist/esm/package.json'))).toBe(false);
   },
 );
 
-test.each(['babel', 'esbuild', 'swc'] as const)(
-  '%s emits native ESM and NodeNext declarations while preserving CJS',
-  async (transformer) => {
+const variants = (['babel', 'esbuild', 'swc'] as const).flatMap((transformer) =>
+  [undefined, 'commonjs', 'module'].map((type) => ({ transformer, type })),
+);
+
+test.each(variants)(
+  '$transformer supports import, require and NodeNext with type=$type',
+  async ({ transformer, type }) => {
+    const esmExt = type === 'module' ? 'js' : 'mjs';
+    const cjsExt = type === 'module' ? 'cjs' : 'js';
+    const esmDts = type === 'module' ? 'ts' : 'mts';
+    const cjsDts = type === 'module' ? 'cts' : 'ts';
+    const packageJson = {
+      name: pkg.name,
+      ...(type ? { type } : {}),
+      exports: {
+        '.': {
+          import: {
+            types: `./dist/esm/index.d.${esmDts}`,
+            default: `./dist/esm/index.${esmExt}`,
+          },
+          require: {
+            types: `./dist/cjs/index.d.${cjsDts}`,
+            default: `./dist/cjs/index.${cjsExt}`,
+          },
+        },
+      },
+    };
     const cwd = fixture({
-      'package.json': pkg,
+      'package.json': packageJson,
       'tsconfig.json': tsconfig,
-      'src/index.ts': `
-      export { value } from '@/value';
-      export * from './nested';
+      'src/index.ts': `export { value } from '@/value'; export * from './nested';
       export { default as legacy } from 'legacy/plugin';
       export { default as modern } from 'modern/feature';
-      export const load = () => import('./nested');
-      export type Value = import('./value').Value;
-    `,
+      export const load = () => import('./nested'); export type Value = import('./value').Value;`,
       'src/value.ts':
         'export const value = 42; export interface Value { value: number }',
-      'src/nested/index.ts': "export { value as nested } from '../value';",
+      'src/nested/index.ts': "export { value as nested } from '../value.js';",
       'node_modules/legacy/package.json': { name: 'legacy' },
       'node_modules/legacy/plugin.js': 'module.exports = 7;',
       'node_modules/legacy/plugin.d.ts':
@@ -275,9 +259,8 @@ test.each(['babel', 'esbuild', 'swc'] as const)(
         type: 'module',
         exports: {
           './feature': {
-            types: './feature.d.ts',
-            import: './feature.js',
-            require: './feature.cjs',
+            import: { types: './feature.d.mts', default: './feature.js' },
+            require: { types: './feature.d.cts', default: './feature.cjs' },
           },
         },
       },
@@ -285,33 +268,51 @@ test.each(['babel', 'esbuild', 'swc'] as const)(
       'node_modules/modern/feature.cjs': 'module.exports = 8;',
       'node_modules/modern/feature.d.ts':
         'declare const feature: 8; export default feature;',
+      'node_modules/modern/feature.d.mts':
+        'declare const feature: 8; export default feature;',
+      'node_modules/modern/feature.d.cts':
+        'declare const feature: 8; export = feature;',
     });
     const userConfig: IFatherConfig = {
-      esm: { transformer, ...esmOptions },
-      cjs: {},
+      esm: { transformer, autoExtension: true, resolveDepSubpath: true },
+      cjs: { transformer, autoExtension: true },
       sourcemap: true,
       targets: { node: '18' },
     };
-    await builder({ cwd, pkg, userConfig });
-    const firstCjs = distToMap(path.join(cwd, 'dist/cjs'));
-    const esm = read(cwd, 'dist/esm/index.js');
-    const dts = read(cwd, 'dist/esm/index.d.ts');
-    expect(esm).toContain('./value.js');
-    expect(esm).toContain('./nested/index.js');
-    expect(esm).toContain('legacy/plugin.js');
-    expect(esm).toContain('modern/feature');
-    expect(esm).not.toContain('modern/feature.js');
-    expect(dts).toContain('./value.js');
-    expect(dts).toContain('./nested/index.js');
-    expect(dts).toContain('legacy/plugin.js');
-    expect(JSON.parse(read(cwd, 'dist/esm/package.json'))).toEqual({
-      type: 'module',
-    });
-    for (const file of ['index.js.map', 'index.d.ts.map']) {
-      const map = JSON.parse(read(cwd, `dist/esm/${file}`));
-      expect(map.sources).toEqual(['../../src/index.ts']);
-      expect(map.mappings).not.toBe('');
+    await builder({ cwd, pkg: packageJson, userConfig });
+    for (const [format, ext, dts] of [
+      ['esm', esmExt, esmDts],
+      ['cjs', cjsExt, cjsDts],
+    ]) {
+      const js = read(cwd, `dist/${format}/index.${ext}`);
+      const types = read(cwd, `dist/${format}/index.d.${dts}`);
+      expect(js).toContain(`./value.${ext}`);
+      expect(js).toContain(`./nested/index.${ext}`);
+      expect(types).toContain(`./value.${ext}`);
+      expect(types).toContain(`./nested/index.${ext}`);
+      expect(read(cwd, `dist/${format}/nested/index.${ext}`)).toContain(
+        `../value.${ext}`,
+      );
+      expect(js).toContain('modern/feature');
+      expect(js).not.toContain('modern/feature.js');
+      if (format === 'esm') {
+        expect(js).toContain('legacy/plugin.js');
+        expect(types).toContain('legacy/plugin.js');
+      }
+      expect(fs.existsSync(path.join(cwd, `dist/${format}/package.json`))).toBe(
+        false,
+      );
+      for (const file of [`index.${ext}`, `index.d.${dts}`]) {
+        const map = JSON.parse(read(cwd, `dist/${format}/${file}.map`));
+        expect(map.file).toBe(file);
+        expect(map.sources).toEqual(['../../src/index.ts']);
+        expect(map.mappings).not.toBe('');
+        expect(read(cwd, `dist/${format}/${file}`)).toContain(
+          `sourceMappingURL=${file}.map`,
+        );
+      }
     }
+    expect(JSON.parse(read(cwd, 'package.json'))).toEqual(packageJson);
     const result = execFileSync(
       process.execPath,
       [
@@ -321,20 +322,21 @@ test.each(['babel', 'esbuild', 'swc'] as const)(
     import { createRequire } from 'node:module';
     const esm = await import('native-esm-fixture');
     const cjs = createRequire(import.meta.url)('native-esm-fixture');
-    console.log(JSON.stringify([esm.value, esm.nested, (await esm.load()).nested, esm.legacy, esm.modern, cjs.value, cjs.legacy, cjs.modern]));
+    console.log(JSON.stringify([esm.value, (await esm.load()).nested, esm.legacy, esm.modern, cjs.value, (await cjs.load()).nested, cjs.legacy, cjs.modern]));
   `,
       ],
       { cwd, encoding: 'utf-8' },
     );
-    expect(JSON.parse(result)).toEqual([42, 42, 42, 7, 8, 42, 7, 8]);
-    write(
-      cwd,
-      'consumer.mts',
-      `import { value, nested, legacy, modern, load, type Value } from 'native-esm-fixture';
-    const n: number = value + nested + legacy + modern;
-    const v: Value = { value: n };
+    expect(JSON.parse(result)).toEqual([42, 42, 7, 8, 42, 42, 7, 8]);
+    for (const ext of ['mts', 'cts'])
+      write(
+        cwd,
+        `consumer.${ext}`,
+        `
+    import { value, nested, legacy, modern, load, type Value } from 'native-esm-fixture';
+    const v: Value = { value: value + nested + legacy + modern };
     load().then(m => { const x: number = m.nested; });`,
-    );
+      );
     try {
       execFileSync(
         process.execPath,
@@ -349,20 +351,22 @@ test.each(['babel', 'esbuild', 'swc'] as const)(
           '--target',
           'es2020',
           'consumer.mts',
+          'consumer.cts',
         ],
         { cwd, stdio: 'pipe' },
       );
     } catch (error: any) {
       throw new Error(error.stdout?.toString() || error.message);
     }
+    const firstCjs = distToMap(path.join(cwd, 'dist/cjs'));
     await builder({
       cwd,
-      pkg,
+      pkg: packageJson,
       userConfig: { ...userConfig, esm: { transformer } },
     });
     expect(distToMap(path.join(cwd, 'dist/cjs'))).toEqual(firstCjs);
-    expect(fs.existsSync(path.join(cwd, 'dist/esm/package.json'))).toBe(false);
     expect(read(cwd, 'dist/esm/index.js')).not.toContain('./value.js');
+    expect(fs.existsSync(path.join(cwd, 'dist/esm/index.mjs'))).toBe(false);
   },
 );
 
@@ -408,13 +412,16 @@ declare const untouched: "from './missing'";
     includeContent: true,
   });
   write(cwd, 'dist/esm/index.js.map', map);
-  const provider = createConfigProviders({ esm: { ...esmOptions } }, {}, cwd)
-    .bundless.esm!;
+  const provider = createConfigProviders(
+    { esm: { redirect, resolveDepSubpath: true } },
+    {},
+    cwd,
+  ).bundless.esm!;
   const outputs = ['index.js', 'index.d.ts'].map((file) => ({
     file: path.join(cwd, 'dist/esm', file),
     sourceFile: path.join(cwd, 'src/index.ts'),
   }));
-  finalizeEsm(outputs, cwd, provider);
+  finalizeOutputs(outputs, cwd, provider);
   const result = read(cwd, 'dist/esm/index.js');
   expect(result).toContain('./nested/index.js?raw=1#hash');
   expect(result).toContain('./dotted.name.js');
@@ -438,7 +445,7 @@ declare const untouched: "from './missing'";
   expect(read(cwd, 'dist/esm/index.d.ts')).toContain('"from \'./missing\'"');
   expect(JSON.parse(read(cwd, 'dist/esm/package.json'))).toEqual({
     sideEffects: false,
-    type: 'module',
+    type: 'commonjs',
   });
   // Inspect the decoded mapping after the longer import on the same line.
   const composed = remapping(
@@ -453,22 +460,20 @@ declare const untouched: "from './missing'";
     code.indexOf('after'),
   ]);
   const files = distToMap(path.join(cwd, 'dist'));
-  finalizeEsm(outputs, cwd, provider);
+  finalizeOutputs(outputs, cwd, provider);
   expect(distToMap(path.join(cwd, 'dist'))).toEqual(files);
 });
 
 test('reports unresolved relative modules with the importing file', async () => {
   const cwd = fixture({ 'src/index.js': "export * from './missing';" });
   await expect(
-    builder({ cwd, pkg: {}, userConfig: { esm: { fullySpecified: true } } }),
-  ).rejects.toThrow(
-    'Cannot resolve fully specified ESM import "./missing" from dist',
-  );
+    builder({ cwd, pkg: {}, userConfig: { esm: { redirect } } }),
+  ).rejects.toThrow('Cannot resolve module reference "./missing" from dist');
 });
 
-test('relocates overrides, marks copied package scopes, and handles cache hits', async () => {
+test('relocates overrides, respects copied package scopes, and handles cache hits', async () => {
   const cwd = fixture({
-    'package.json': pkg,
+    'package.json': { ...pkg, type: 'module' },
     'tsconfig.json': tsconfig,
     'src/index.ts': "export { value } from './nested';",
     'src/nested/index.ts': 'export const value = 12;',
@@ -476,26 +481,25 @@ test('relocates overrides, marks copied package scopes, and handles cache hits',
   });
   const userConfig: IFatherConfig = {
     esm: {
-      fullySpecified: true,
-      outputPackageType: 'module',
+      autoExtension: true,
       overrides: { 'src/nested': { output: 'custom/nested' } },
     },
   };
   delete process.env.FATHER_CACHE;
   try {
-    await builder({ cwd, pkg, userConfig });
+    await builder({ cwd, pkg: { ...pkg, type: 'module' }, userConfig });
     expect(read(cwd, 'dist/esm/index.js')).toContain(
-      '../../custom/nested/index.js',
+      '../../custom/nested/index.mjs',
     );
     expect(read(cwd, 'dist/esm/index.d.ts')).toContain(
-      '../../custom/nested/index.js',
+      '../../custom/nested/index.mjs',
     );
     expect(JSON.parse(read(cwd, 'custom/nested/package.json'))).toEqual({
       sideEffects: false,
-      type: 'module',
+      type: 'commonjs',
     });
     const first = distToMap(path.join(cwd, 'dist'));
-    await builder({ cwd, pkg, userConfig });
+    await builder({ cwd, pkg: { ...pkg, type: 'module' }, userConfig });
     expect(distToMap(path.join(cwd, 'dist'))).toEqual(first);
     expect(
       execFileSync(
@@ -515,60 +519,231 @@ test('relocates overrides, marks copied package scopes, and handles cache hits',
   }
 });
 
-test('watch rewrites changed JS, copied declarations and newly added modules', async () => {
-  const cwd = fixture({ 'src/index.js': 'export const initial = 1;' });
-  const watcher = await builder({
-    cwd,
-    pkg: {},
-    userConfig: {
-      esm: {
-        fullySpecified: true,
-        outputPackageType: 'module',
-        transformer: 'esbuild',
-      },
-    },
-    watch: true,
-  });
-  try {
+async function waitFor(check: () => boolean) {
+  const deadline = Date.now() + 15000;
+  while (!check()) {
+    if (Date.now() > deadline) throw new Error('Timed out waiting for output');
     await new Promise((resolve) => setTimeout(resolve, 100));
-    write(cwd, 'src/new/index.js', 'export const value = 2;');
-    write(cwd, 'src/new/index.d.ts', 'export declare const value: 2;');
-    write(cwd, 'src/index.js', "export { value } from './new';");
-    write(cwd, 'src/index.d.ts', "export { value } from './new';");
-    const deadline = Date.now() + 15000;
-    while (true) {
-      if (
-        fs.existsSync(path.join(cwd, 'dist/esm/index.d.ts')) &&
-        read(cwd, 'dist/esm/index.js').includes('./new/index.js') &&
-        read(cwd, 'dist/esm/index.d.ts').includes('./new/index.js')
-      )
-        break;
-      if (Date.now() > deadline)
-        throw new Error('Timed out waiting for native ESM watch output');
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    }
-    expect(JSON.parse(read(cwd, 'dist/esm/package.json'))).toEqual({
-      type: 'module',
-    });
-  } finally {
-    await watcher.close();
   }
-});
+}
 
-test('parallel build finalizes native ESM after workers finish', () => {
+test.each([undefined, 'module'])(
+  'watch rewrites and removes JS, declarations and maps with type=%s',
+  async (type) => {
+    const packageJson = type ? { type } : {};
+    const cwd = fixture({
+      'package.json': packageJson,
+      'src/index.js': 'export const initial = 1;',
+    });
+    // Node 24's native Windows watcher can abort on temporary directory events.
+    // Polling still exercises Father's real watch build and removal handlers.
+    const previousPolling = process.env.CHOKIDAR_USEPOLLING;
+    if (process.platform === 'win32') process.env.CHOKIDAR_USEPOLLING = 'true';
+    const watcher = await builder({
+      cwd,
+      pkg: packageJson,
+      userConfig: {
+        esm: { autoExtension: true, transformer: 'esbuild' },
+        cjs: { autoExtension: true },
+        sourcemap: true,
+      },
+      watch: true,
+    });
+    const variants = [
+      ['esm', type ? 'js' : 'mjs', type ? 'ts' : 'mts'],
+      ['cjs', type ? 'cjs' : 'js', type ? 'cts' : 'ts'],
+    ];
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      write(cwd, 'src/new/index.js', 'export const value = 2;');
+      write(cwd, 'src/new/index.d.ts', 'export declare const value: 2;');
+      write(cwd, 'src/index.js', "export { value } from './new';");
+      write(cwd, 'src/index.d.ts', "export { value } from './new';");
+      await waitFor(() =>
+        variants.every(
+          ([format, ext, dts]) =>
+            fs.existsSync(path.join(cwd, `dist/${format}/index.d.${dts}`)) &&
+            read(cwd, `dist/${format}/index.${ext}`).includes(
+              `./new/index.${ext}`,
+            ) &&
+            read(cwd, `dist/${format}/index.d.${dts}`).includes(
+              `./new/index.${ext}`,
+            ),
+        ),
+      );
+      fs.unlinkSync(path.join(cwd, 'src/new/index.js'));
+      fs.unlinkSync(path.join(cwd, 'src/new/index.d.ts'));
+      await waitFor(() =>
+        variants.every(([format, ext, dts]) =>
+          [`index.${ext}`, `index.${ext}.map`, `index.d.${dts}`].every(
+            (file) =>
+              !fs.existsSync(path.join(cwd, `dist/${format}/new/${file}`)),
+          ),
+        ),
+      );
+    } finally {
+      await watcher.close();
+      if (previousPolling === undefined) delete process.env.CHOKIDAR_USEPOLLING;
+      else process.env.CHOKIDAR_USEPOLLING = previousPolling;
+    }
+  },
+);
+
+test('parallel build emits and references selected extensions', () => {
   const cwd = fixture({
     'package.json': pkg,
     'src/index.js': "export { value } from './nested';",
     'src/nested/index.js': 'export const value = 5;',
-    '.fatherrc.js': `export default { esm: { parallel: true, fullySpecified: true, outputPackageType: 'module' } };`,
+    '.fatherrc.js':
+      'export default { esm: { parallel: true, autoExtension: true }, cjs: { parallel: true, autoExtension: true } };',
   });
   execFileSync(
     process.execPath,
     [path.resolve(__dirname, '../bin/father.js'), 'build'],
     { cwd, env: { ...process.env, APP_ROOT: cwd }, stdio: 'pipe' },
   );
-  expect(read(cwd, 'dist/esm/index.js')).toContain('./nested/index.js');
-  expect(JSON.parse(read(cwd, 'dist/esm/package.json'))).toEqual({
-    type: 'module',
+  expect(read(cwd, 'dist/esm/index.mjs')).toContain('./nested/index.mjs');
+  expect(read(cwd, 'dist/cjs/index.js')).toContain('./nested/index.js');
+  expect(fs.existsSync(path.join(cwd, 'dist/esm/package.json'))).toBe(false);
+});
+
+test('autoExtension allows independent redirect overrides and preserves copied declaration maps', async () => {
+  const map = {
+    version: 3,
+    file: 'index.d.ts',
+    sources: ['../../types/original.ts'],
+    names: [],
+    mappings: 'AAAA',
+  };
+  const cwd = fixture({
+    'src/index.js': "export * from './value';",
+    'src/index.d.ts':
+      "export * from './value';\n//# sourceMappingURL=index.d.ts.map\n",
+    'src/index.d.ts.map': map,
+    'src/value.js': 'export const value = 1;',
+    'src/value.d.ts': 'export declare const value: 1;',
   });
+  await builder({
+    cwd,
+    pkg: {},
+    userConfig: {
+      esm: { autoExtension: true, redirect: { js: { extension: false } } },
+    },
+  });
+  expect(read(cwd, 'dist/esm/index.mjs')).not.toContain('./value.mjs');
+  expect(read(cwd, 'dist/esm/index.d.mts')).toContain('./value.mjs');
+  expect(read(cwd, 'dist/esm/index.d.mts')).toContain(
+    'sourceMappingURL=index.d.mts.map',
+  );
+  expect(JSON.parse(read(cwd, 'dist/esm/index.d.mts.map')).sources).toEqual(
+    map.sources,
+  );
+  await builder({
+    cwd,
+    pkg: {},
+    userConfig: {
+      esm: { autoExtension: true, redirect: { dts: { extension: false } } },
+    },
+  });
+  expect(read(cwd, 'dist/esm/index.mjs')).toContain('./value.mjs');
+  expect(read(cwd, 'dist/esm/index.d.mts')).not.toContain('./value.mjs');
+});
+
+test('cached builds select new filenames when the package type changes', async () => {
+  const cwd = fixture({
+    'package.json': {},
+    'tsconfig.json': tsconfig,
+    'src/index.ts': "export { value } from './value';",
+    'src/value.ts': 'export const value = 1;',
+  });
+  const userConfig = {
+    esm: { autoExtension: true },
+    cjs: { autoExtension: true },
+    sourcemap: true,
+  };
+  delete process.env.FATHER_CACHE;
+  try {
+    await builder({ cwd, pkg: {}, userConfig });
+    const first = distToMap(path.join(cwd, 'dist'));
+    write(cwd, 'package.json', { type: 'module' });
+    await builder({ cwd, pkg: { type: 'module' }, userConfig });
+    expect(read(cwd, 'dist/esm/index.js')).toContain('./value.js');
+    expect(read(cwd, 'dist/cjs/index.cjs')).toContain('./value.cjs');
+    expect(read(cwd, 'dist/cjs/index.d.cts')).toContain('./value.cjs');
+    expect(fs.existsSync(path.join(cwd, 'dist/esm/index.mjs'))).toBe(false);
+    write(cwd, 'package.json', {});
+    await builder({ cwd, pkg: {}, userConfig });
+    expect(distToMap(path.join(cwd, 'dist'))).toEqual(first);
+  } finally {
+    process.env.FATHER_CACHE = 'none';
+  }
+});
+
+test.each([undefined, 'module'])(
+  'dual-format builds can share a directory with type=%s',
+  async (type) => {
+    const packageJson = type ? { type } : {};
+    const cwd = fixture({
+      'package.json': packageJson,
+      'tsconfig.json': tsconfig,
+      'src/index.ts': "export { value } from './value';",
+      'src/value.ts': 'export const value = 9;',
+    });
+    const config = { autoExtension: true, output: 'dist' };
+    await builder({
+      cwd,
+      pkg: packageJson,
+      userConfig: { esm: config, cjs: config },
+    });
+    const esmExt = type ? 'js' : 'mjs';
+    const cjsExt = type ? 'cjs' : 'js';
+    const result = execFileSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '-e',
+        `
+    import { createRequire } from 'node:module';
+    const esm = await import('./dist/index.${esmExt}');
+    const cjs = createRequire(import.meta.url)('./dist/index.${cjsExt}');
+    console.log(esm.value + cjs.value);
+  `,
+      ],
+      { cwd, encoding: 'utf-8' },
+    );
+    expect(result.trim()).toBe('18');
+    expect(read(cwd, `dist/index.d.${type ? 'ts' : 'mts'}`)).toContain(
+      `./value.${esmExt}`,
+    );
+    expect(read(cwd, `dist/index.d.${type ? 'cts' : 'ts'}`)).toContain(
+      `./value.${cjsExt}`,
+    );
+  },
+);
+
+test('CJS resolves renamed modules in require.resolve and declaration import assignments', async () => {
+  const packageJson = { type: 'module' };
+  const cwd = fixture({
+    'package.json': packageJson,
+    'src/index.js':
+      "exports.value = require('./value').value; exports.filename = require.resolve('./value');",
+    'src/index.d.ts': "import value = require('./value'); export { value };",
+    'src/value.js': 'exports.value = 6;',
+    'src/value.d.ts': 'export declare const value: 6;',
+  });
+  await builder({
+    cwd,
+    pkg: packageJson,
+    userConfig: { cjs: { autoExtension: true } },
+  });
+  expect(read(cwd, 'dist/cjs/index.d.cts')).toContain('require("./value.cjs")');
+  const result = execFileSync(
+    process.execPath,
+    [
+      '-e',
+      `const m = require('./dist/cjs/index.cjs'); console.log(m.value, m.filename.endsWith('value.cjs'));`,
+    ],
+    { cwd, encoding: 'utf-8' },
+  );
+  expect(result.trim()).toBe('6 true');
 });


### PR DESCRIPTION
Father's bundless builds normally emit `.js` and `.d.ts`, leaving consumers to account for package types and extensionless module references. Add explicit options to produce matching runtime and declaration filenames for native Node ESM and CommonJS consumers.

`esm.autoExtension` and `cjs.autoExtension` use the package type to select filenames:

| Package type | ESM | CJS |
| --- | --- | --- |
| `module` | `.js` / `.d.ts` | `.cjs` / `.d.cts` |
| `commonjs` or absent | `.mjs` / `.d.mts` | `.js` / `.d.ts` |

The filename policy and `autoExtension` name follow Rslib. Father matches declaration extensions at the same time. No package.json is generated or modified. Copied package scopes and relocated overrides are respected, and both formats can share an output directory when their extensions differ.

```ts
export default {
  esm: { platform: 'node', autoExtension: true },
  cjs: { autoExtension: true },
};
```

`redirect.js.extension` and `redirect.dts.extension` control relative module references independently, using Rslib's naming. They follow `autoExtension` by default and can be explicitly overridden. Rewriting covers imports, re-exports, literal dynamic imports, CJS `require` / `require.resolve`, and declaration references. Source map filenames, URLs and mappings follow the resulting output.

`esm.resolveDepSubpath` remains independent and defaults to false, following the behavior of tsdown's `deps.resolveDepSubpath`: only resolvable subpaths of packages without `exports` are completed. Public exports and package roots retain their specifiers.

Compatibility: all new behavior is opt-in. Neither `exports.import` nor root `type` metadata enables it. Without new options, existing Father 4 output remains unchanged. Users enabling automatic extensions must update their published runtime and type entry points. Chinese and English documentation includes both package-type policies and a dual-format publishing example.

Related: https://github.com/react-component/father-plugin/pull/27

Validation:

- `pnpm run build` and `pnpm exec tsc --noEmit`
- Full Jest suite with isolated workers: `pnpm exec jest --maxWorkers=1 --workerIdleMemoryLimit=1MB` — 17 suites, 183 tests and 1 snapshot passed
- Babel, esbuild and SWC each tested with module, commonjs and absent package types; actual Node import/require and TypeScript NodeNext ESM/CJS consumers.
- Option independence, copied declaration maps, relocated package scopes, cache hits and package-type changes, shared output directories, parallel builds, and watch updates/deletions. Watch tests use polling on Windows to avoid the Node 24 native fs-event assertion observed in the previous CI run.
- Compared unchanged configurations against Father 4.6.36 (`2ca945c`): all 9 transformer/metadata combinations produced byte-identical JS, declarations, maps, CJS and copied package metadata.
- The existing dev file-change test now waits for both ESM and UMD output contents, avoiding a fixed-delay race under CI load; all 5 dev tests passed locally.
- Prettier and `git diff --check`.
